### PR TITLE
Added translations, as well as other translation improvements

### DIFF
--- a/src/components/BalanceComponent.vue
+++ b/src/components/BalanceComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <CardComponent
-      :header="$t('c_currentSaldo.saldo')"
-      :action="showOption ? 'Increase Online' : ''"
+      :header="$t('c_currentBalance.balance')"
+      :action="showOption ? t('c_currentBalance.Increase balance') : ''"
       routerLink="balance"
   >
     <div class="body">
@@ -16,6 +16,7 @@ import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import { computed, ref, onMounted } from 'vue';
 import type { UserResponse } from '@sudosos/sudosos-client';
 import apiService from '@/services/ApiService';
+import { useI18n } from "vue-i18n";
 
 const props = defineProps({
   user: {
@@ -28,6 +29,7 @@ const props = defineProps({
   }
 });
 
+const { t } = useI18n();
 const userStore = useUserStore();
 
 const balanceFromApi = ref<string | undefined>(undefined);

--- a/src/components/BalanceComponent.vue
+++ b/src/components/BalanceComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <CardComponent
       :header="$t('c_currentBalance.balance')"
-      :action="showOption ? t('c_currentBalance.Increase balance') : ''"
+      :action="showOption ? $t('c_currentBalance.Increase balance') : ''"
       routerLink="balance"
   >
     <div class="body">
@@ -16,7 +16,6 @@ import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import { computed, ref, onMounted } from 'vue';
 import type { UserResponse } from '@sudosos/sudosos-client';
 import apiService from '@/services/ApiService';
-import { useI18n } from "vue-i18n";
 
 const props = defineProps({
   user: {
@@ -29,7 +28,6 @@ const props = defineProps({
   }
 });
 
-const { t } = useI18n();
 const userStore = useUserStore();
 
 const balanceFromApi = ref<string | undefined>(undefined);

--- a/src/components/TopNavbar.vue
+++ b/src/components/TopNavbar.vue
@@ -64,7 +64,7 @@ const leftItems = ref([
     label: () => t('app.Transactions'),
   },
   {
-    label: () => t('app.Saldo'),
+    label: () => t('app.Balance'),
     to: '/balance',
   },
   {
@@ -140,15 +140,19 @@ const rightItems = ref([
     icon: 'pi pi-globe',
     items: [
       {
-        label: t('app.Netherlands'),
+        label: () => t('app.Netherlands'),
+        disabled: () => locale.value == 'nl',
         command: () => {
           locale.value = 'nl';
+          localStorage.setItem('locale', 'nl')
         },
       },
       {
-        label: t('app.English'),
+        label: () => t('app.English'),
+        disabled: () => locale.value == 'en',
         command: () => {
           locale.value = 'en';
+          localStorage.setItem('locale', 'en')
         },
       },
     ]

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,7 +26,7 @@
   },
   "app": {
     "Transactions": "Transactions",
-    "Saldo": "Balance",
+    "Balance": "Balance",
     "Points of Sale": "Points of Sale",
     "Overview": "POS Overview",
     "Create": "Create",
@@ -71,8 +71,12 @@
   "transactions": {
     "Transactions": "Transactions"
   },
-  "saldo": {
-    "Saldo": "Balance"
+  "balance": {
+    "Balance": "Balance",
+    "Balance increase amount": "Balance increase amount",
+    "Start payment": "Start payment",
+    "Increase balance": "Increase balance",
+    "Price": "Price"
   },
   "pointOfSaleOverview": {
     "Point of sale overview": "Point of sale overview"
@@ -256,15 +260,15 @@
   "banners": {
     "Banners": "Banners"
   },
-  "c_currentSaldo": {
-    "saldo": "balance",
+  "c_currentBalance": {
+    "balance": "Balance",
     "upgrade online": "increase online",
     "topup": "You will be topping up with €{amount}",
     "cashtopup": "It is no longer possible to increase your balance in cash during the 'borrel'",
     "increase": "Balance increase amount:",
     "currency": "€",
     "startPayment": "Start Payment",
-    "Increase Saldo": "Increase Saldo"
+    "Increase balance": "Increase balance"
   },
   "c_recentTransactionsTable": {
     "recent transactions": "recent transactions",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -23,7 +23,7 @@
   },
   "app": {
     "Transactions": "Transacties",
-    "Saldo": "Saldo",
+    "Balance": "Saldo",
     "Points of Sale": "Verkooppunten",
     "Overview": "Overzicht POS",
     "Create": "Aanmaken",
@@ -66,8 +66,12 @@
   "transactions": {
     "Transactions": "Transacties"
   },
-  "saldo": {
-    "Saldo": "Saldo"
+  "balance": {
+    "Balance": "Saldo",
+    "Balance increase amount": "Saldo verhogen met:",
+    "Start payment": "Betaal",
+    "Increase balance": "Verhoog saldo",
+    "Price": "Prijs"
   },
   "pointOfSaleOverview": {
     "Point of sale overview": "Verkooppunt overzicht"
@@ -250,11 +254,12 @@
   "banners": {
     "Banners": "Banners"
   },
-  "c_currentSaldo": {
-    "saldo": "saldo",
-    "upgrade online": "online opwaarderen",
+  "c_currentBalance": {
+    "balance": "Saldo",
+    "upgrade online": "Online opwaarderen",
     "of which": "Waarvan",
-    "fine": "boete"
+    "fine": "boete",
+    "Increase balance": "Saldo opwaarderen"
   },
   "c_recentTransactionsTable": {
     "recent transactions": "recente transacties",

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,8 +29,9 @@ import nl from "./locales/nl.json";
 
 const app = createApp(App);
 
+
 const i18n = createI18n({
-    locale: 'en',
+    locale: localStorage.getItem('locale') || 'en',
     fallbackLocale: 'en',
     legacy: false,
     globalInjection: true,

--- a/src/views/BalanceView.vue
+++ b/src/views/BalanceView.vue
@@ -1,20 +1,19 @@
 <template>
   <div class="page-container">
-    <div class="page-title">{{ $t('c_currentSaldo.saldo') }}</div>
+    <div class="page-title">{{ $t('c_currentBalance.balance') }}</div>
     <TopupModal v-model:visible="visible" :amount="amountValue"/>
     <div class="content-wrapper">
       <CardComponent
-          :action="$t('c_currentSaldo.startPayment')"
-          :header="$t('c_currentSaldo.Increase Saldo')"
-          class="increase-saldo-card"
+          :action="$t('balance.Start payment')"
+          :header="$t('balance.Increase balance')"
+          class="increase-balance-card"
           :func="showDialog"
       >
-        <p id="cash-notice">{{ $t('c_currentSaldo.cashtopup') }}</p>
         <div id="balance-increase-form">
-          <p id="balance-increase-title">{{ $t('c_currentSaldo.increase') }}</p>
+          <p id="balance-increase-title">{{ $t('balance.Balance increase amount') }}</p>
           <div class="p-inputgroup flex-1">
-            <span class="p-inputgroup-addon">{{ $t('c_currentSaldo.currency') }}</span>
-            <InputNumber v-model="amountValue" :placeholder="$t('c_productInfoModal.Price')" inputId="amount"/>
+            <span class="p-inputgroup-addon">{{ '€' }}</span>
+            <InputNumber class="cashInput" v-model="amountValue" :placeholder="$t('balance.Price')" inputId="amount"/>
           </div>
         </div>
       </CardComponent>
@@ -55,5 +54,6 @@ const showDialog = () => {
 
 .p-inputgroup {
   width: 25%;
+  min-width: 120px;
 }
 </style>


### PR DESCRIPTION
- Added translations where they were still missing, only place where it still is missing is in the Recent transactions, but those are hardcoded either way so I'm expected them to be overhauled.
- Renamed a bunch of in-code cases of "Saldo" cause that is not an English word :)
- renamed some things that should be not c_ in the balance view, but should be improved up on more in a translation file overhaul.


Fixes #50 