### PR TITLE
Ci/update GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -21,7 +21,7 @@ body:
         id: reproduction
         attributes:
             label: Steps to reproduce
-            description: Clearly describe which steps or actions you have taken to arrive at the problem. If you have some experience with the code, please link to the specific pieces of code or fork [this repo](https://github.com/GEWIS/gewisdb), create a failing test case, and then link to your fork.
+            description: Clearly describe which steps or actions you have taken to arrive at the problem. If you have some experience with the code, please link to the specific pieces of code.
             placeholder: I did X, then Y, before arriving at Z, when ERROR ...
         validations:
             required: true

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,5 +1,6 @@
 name: "🐛 Bug Report"
 description: Report a bug found while using the SudoSOS frontend.
+title: "[Bug]: "
 labels: ["Type: Bug", "Status: Triage"]
 body:
     -   type: textarea
@@ -24,23 +25,6 @@ body:
             placeholder: I did X, then Y, before arriving at Z, when ERROR ...
         validations:
             required: true
-    -   type: input
-        id: version
-        attributes:
-            label: Database version
-            placeholder: ex. v2.0 (1a64154)
-        validations:
-            required: true
-    -   type: dropdown
-        id: os
-        attributes:
-            label: What operating are you seeing the problem on?
-            multiple: true
-            options:
-                - Linux
-                - macOS
-                - Windows
-                - Other
     -   type: dropdown
         id: browsers
         attributes:
@@ -57,5 +41,5 @@ body:
         id: other
         attributes:
             label: Other information
-            description: Any other details? Things like browser and operating system version should go here.
+            description: Any other details?
 

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,5 +1,5 @@
 name: "✨ Feature Request"
-description: Suggest a feature or enhancement to improve SudoSOS frontend. Please make sure that this a feature for the frontend and not the [backend](https://github.com/GEWIS/sudosos-backend).
+description: Suggest a feature or enhancement to improve SudoSOS frontend. Please make sure that this a feature for the frontend and not the backend.
 labels: ["Type: Idea"]
 body:
     -   type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,0 @@
-blank_issues_enabled: false
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,8 +14,10 @@ Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be aut
 -->
 
 ## Types of changes
-<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
-- [ ] Bug fix _(non-breaking change which fixes an issue)_
-- [ ] New feature _(non-breaking change which adds functionality)_
-- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
-- [ ] Documentation improvement
+<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
+- Bug fix _(non-breaking change which fixes an issue)_
+- New feature _(non-breaking change which adds functionality)_
+- Breaking change _(fix or feature that would cause existing functionality to change)_
+- Documentation improvement
+- Style _(Change that do not affect the functionality of the code)_
+- CI/CD _(Changes to the CI/CD configuration)_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,6 @@ Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be aut
 `ABC-YYMM-XXX`.
 -->
 
-Fixes GH-NNN.
-
 ## Types of changes
 <!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->
 - [ ] Bug fix _(non-breaking change which fixes an issue)_


### PR DESCRIPTION
Fixes some minor changes in the github templates, somehow not spotted in the original pull request, or based on the experience.

# Description
- Removed the database references and OS references in the bug report.
- Re-did "types of changes" in pull request to make it better fit the github template


## Related issues/external references
-

## Types of changes
If only I had the options from this pull request here :(
