### PR TITLE
feat(topup): Form validation for going above 150 euros

### DIFF
--- a/apps/dashboard/src/components/BalanceWithTopupComponent.vue
+++ b/apps/dashboard/src/components/BalanceWithTopupComponent.vue
@@ -87,6 +87,13 @@ const productSchema = toTypedSchema(
           return value >= 10 || Math.round(value * -100) == userBalance.value?.amount.amount;
         }
       )
+      .test(
+        'is-total-less-than-150',
+        `Your new balance cannot surpass €150.`,
+        (value) => {
+          return userBalance.value!!.amount.amount + value*100 <= 15000
+        }
+      )
   })
 );
 


### PR DESCRIPTION
You cannot top up above 150 euro's anymore

# Description
Because of https://github.com/GEWIS/sudosos-backend/pull/179 the frontend will silently fail when getting above 150 euros

## Related issues/external references
#199 

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
