### PR TITLE
Fix: links in tos

### DIFF
--- a/apps/dashboard/src/components/TermsOfServiceModal.vue
+++ b/apps/dashboard/src/components/TermsOfServiceModal.vue
@@ -13,7 +13,7 @@
           <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
              <p>SudoSOS Terms of Service - version 1.0 (14/08/2022)</p>
           <!-- TOS is also english so we can leave this untranslated -->
-            <div v-html="tos"></div>
+            <div class="tosText" v-html="tos"></div>
         </div>
         <template #footer>
             <Button label="Ok" @click="visible = false" autofocus />
@@ -44,6 +44,10 @@ const visible = ref(false);
 
 .tosModal {
     max-width: 75vw
+}
+
+.tosText * {
+  color: var(--text-color);
 }
 
 </style>


### PR DESCRIPTION
The links in the TOS were blue, this was inconsistent with the contact modal

# Description
![image](https://github.com/GEWIS/sudosos-frontend/assets/31625323/3339d631-b46c-4860-918c-709b61bc92d7)


## Related issues/external references
none

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
