### PR TITLE
fix(point-of-sale): add a working PWA manifest that fixes viewport issues

### DIFF
--- a/apps/point-of-sale/index.html
+++ b/apps/point-of-sale/index.html
@@ -5,8 +5,8 @@
       <link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png">
       <link rel="icon" type="image/png" sizes="32x32" href="/favicon/favicon-32x32.png">
       <link rel="icon" type="image/png" sizes="16x16" href="/favicon/favicon-16x16.png">
-      <link rel="manifest" href="/favicon/site.webmanifest">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link rel="manifest" href="favicon/manifest.json">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0"/>
     <title>SudoSOS Point Of Sale</title>
   </head>
   <body>

--- a/apps/point-of-sale/public/favicon/manifest.json
+++ b/apps/point-of-sale/public/favicon/manifest.json
@@ -1,0 +1,24 @@
+{
+  "theme_color": "#8936FF",
+  "background_color": "#2EC6FE",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "orientation": "any",
+  "display": "fullscreen",
+  "dir": "auto",
+  "lang": "en-GB",
+  "name": "SudoSOS Point of Sale",
+  "short_name": "SudoPOS",
+  "start_url": "https://sudopos.gewis.nl/",
+  "scope": "https://sudopos.gewis.nl/"
+}

--- a/apps/point-of-sale/public/favicon/manifest.json
+++ b/apps/point-of-sale/public/favicon/manifest.json
@@ -1,6 +1,6 @@
 {
-  "theme_color": "#8936FF",
-  "background_color": "#2EC6FE",
+  "theme_color": "#333333",
+  "background_color": "#D40000",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",

--- a/apps/point-of-sale/public/favicon/site.webmanifest
+++ b/apps/point-of-sale/public/favicon/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
# Description
Browsers suck, chrome sucks, firefox, sucks, edge also sucks but for something suckless reason it sucks a _bit_ less. (still sucks though)

## Related issues/external references
Everybody of the BAC complaining all the god damn time that the checkout button disappears because the tablet decides to increase the viewport by 300 ish pixels when you open the keyboard.

Why? Because standards are for bitches, and everyone just wings it. (Because edge _is_ chromium! Why does it work on edge and not on chrome?!!!!)

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_