### PR TITLE
Fix(pos): styling

### DIFF
--- a/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
+++ b/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container-grid-wrapper flex-1 h-full mb-3 pr-7 mr-3 mt-2">
+  <div class="container-grid-wrapper flex-1 h-full mb-3 pr-6 mr-3 mt-2" ref="wrapper">
     <div class="container gap-3 pr-5">
       <ProductComponent
           v-for="product in sortedProducts"
@@ -39,6 +39,7 @@ const props = defineProps({
 });
 
 const searchQuery = ref(props.searchQuery);
+const wrapper = ref();
 
 watch(() => props.searchQuery, (newValue) => {
   searchQuery.value = newValue;
@@ -46,6 +47,7 @@ watch(() => props.searchQuery, (newValue) => {
 
 const getFilteredProducts = () => {
   if (!props.pointOfSale) return [];
+  wrapper.value?.scrollTo(0, 0);
 
   let filteredProducts = props.pointOfSale.containers.flatMap((container) => {
     return container.products.map((product) => ({

--- a/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
+++ b/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="container-grid-wrapper flex-1 h-full mb-3 mr-3">
-    <div class="container grid gap-2 pr-5 pb-3">
+  <div class="container-grid-wrapper flex-1 h-full mb-3 pr-7 mr-3 mt-2">
+    <div class="container gap-3 pr-5">
       <ProductComponent
           v-for="product in sortedProducts"
           :key="`${product.product.id}-${product.container.id}`"
@@ -115,6 +115,7 @@ const sortedProducts = computed(() => {
 
   > .container {
     grid-template-columns: repeat(auto-fill, minmax($product-column-width, 1fr));
+    display: grid;
   }
 }
 </style>

--- a/apps/point-of-sale/src/components/ProductComponent.vue
+++ b/apps/point-of-sale/src/components/ProductComponent.vue
@@ -122,7 +122,7 @@ const startFlyingAnimation = async () => {
 }
 
 .product-card {
-  padding: 1rem 0 8px 0;
+  padding: 0 0 8px 0;
   height: fit-content;
   border-radius: $border-radius;
   overflow: hidden;

--- a/apps/point-of-sale/src/scss/_variables.scss
+++ b/apps/point-of-sale/src/scss/_variables.scss
@@ -6,7 +6,7 @@
   --gewis-red: rgba(212, 0, 0, 1);
   --gewis-dark-red: #c40000;
   /* Product card width */
-  --product-card-width: 160px;
+  --product-card-width: 128px;
   --accent-color: rgba(212, 0, 0, 1);
 }
 
@@ -32,7 +32,7 @@ $border-radius-sm: 10px;
 $border-radius-xs: 5px;
 
 /* Products */
-$product-column-width: 160px;
+$product-column-width: 128px;
 $product-card-size: 128px;
 $product-price-height: 15px;
 


### PR DESCRIPTION
# Description
The product display is now actually a grid again, nicely spacing out the products over the full width. Note, I increased the amount of product columns for PCGEWISC/D and the tablet to 5.  Also fixed an issue where the scroll of products would not be reset if you change categories or search something.

@SuperVK this might be a place where AB testing would be nice, as I am uncertain how the 4 vs 5 products would feel like.

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_