### PR TITLE
fix(dashboard): allow fractional numeric input on phones for topup

### DIFF
--- a/apps/dashboard/src/modules/user/components/balance/BalanceWithTopup.vue
+++ b/apps/dashboard/src/modules/user/components/balance/BalanceWithTopup.vue
@@ -41,7 +41,7 @@
                 }
               "
               :inputProps="{
-                inputmode: 'numeric',
+                inputmode: 'decimal',
                 class: 'w-full'
               }" />
           </div>


### PR DESCRIPTION
# Description
Fixes bug where iPhone us unable to input fractional numbers into the topup modal.

## Related issues/external references
#244 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
