### PR TITLE
Proxy api requests through vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,3 @@ You can quickly start development directly in your browser by using [Codespaces]
 - Run `cd apps/dashboard` or `cd apps/point-of-sale` in the terminal. 
 - Run `npm run dev` to start the development environment.
 - You can access the dashboard and point of sale at `localhost:5173` and `localhost:5174` respectively.
-
-### Set up browser for CORS
-By default no network requests are allowed from other hosts to `sudosos.test.gewis.nl`. This will prevent critical network requests like authentication from working correctly. To allow this, CORS will need to be disabled. This can be done by using an [extension](https://addons.mozilla.org/en-US/firefox/addon/cors-everywhere/) that can disable CORS. Alternatively, if you are using chrome, [you can directly run it without CORS](https://stackoverflow.com/questions/3102819/disable-same-origin-policy-in-chrome).

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -1,5 +1,8 @@
-VITE_APP_API_BASE='https://sudosos.test.gewis.nl/api/v1'
+VITE_APP_API_BASE='http://localhost:5173/api'
 VITE_APP_IMAGE_BASE='https://sudosos.test.gewis.nl/static/'
 VITE_APP_GEWIS_TOKEN=sudosos-dev
 VITE_APP_STRIPE_PUBLISHABLE_KEY='pk_test_51GsQ83CTbnWP3CTYRobkOgrA4EjkHqvAN6FpDCccxfXayLzj4prFU0GeMIefYW0pvdwXuXqpmqJVLnf6bUyvNJ2T009bK0Sn1L'
 VITE_APP_STRIPE_RETURN_URL='http://localhost:5173/'
+
+# Where the local api requests should be proxied to
+VITE_DEV_API_BASE='https://sudosos.test.gewis.nl/api/v1'

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -1,19 +1,32 @@
 import { fileURLToPath, URL } from 'node:url';
 
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    vue(),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+
+  return {
+    plugins: [
+      vue(),
+    ],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url))
+      }
+    },
+    optimizeDeps: {
+      exclude: ['ToastService'],
+    },
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_DEV_API_BASE,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        }
+      }
     }
-  },
-  optimizeDeps: {
-    exclude: ['ToastService'],
-  },
+  };
 });

--- a/apps/point-of-sale/.env.example
+++ b/apps/point-of-sale/.env.example
@@ -1,2 +1,5 @@
-VITE_APP_API_BASE='https://sudosos.test.gewis.nl/api/v1/'
+VITE_APP_API_BASE='http://localhost:5174/api'
 VITE_APP_IMAGE_BASE='https://sudosos.test.gewis.nl/static/'
+
+# Where the local api requests should be proxied to
+VITE_DEV_API_BASE='https://sudosos.test.gewis.nl/api/v1'

--- a/apps/point-of-sale/vite.config.ts
+++ b/apps/point-of-sale/vite.config.ts
@@ -1,31 +1,42 @@
 import { fileURLToPath, URL } from 'node:url';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import useGitInfo from "./vite.config.plugin-git-info";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [
-    vue(),
-  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    }
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        additionalData: `
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+
+  return {
+    plugins: [
+      vue(),
+    ],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      }
+    },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          additionalData: `
               @import "./src/scss/styles.scss";
             `
+        }
       }
+    },
+    server: {
+      port: 5174,
+      proxy: {
+        '/api': {
+          target: env.VITE_DEV_API_BASE,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        }
+      }
+    },
+    define: {
+      ...useGitInfo(),
     }
-  },
-  server: {
-    port: 5174
-  },
-  define: {
-    ...useGitInfo(),
-  }
+  };
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
proxy api requests through vite to circumvent CORS issues

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
You do not need to disable CORS, because it is just making requests to the vite server, which will proxy it to the correct api.

Adds an extra env variable for the url to which you want to proxy, eg localhost:3000 or sudosos.test.gewis.nl/api/v1

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
#256 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- CI/CD _(Changes to the CI/CD configuration)_
