### PR TITLE
fix: POS screens now also have 5 columns

### DIFF
--- a/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
+++ b/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container-grid-wrapper flex-1 h-full mb-3 pr-6 mr-3 mt-2" ref="wrapper">
-    <div class="container gap-3 pr-5">
+    <div class="container gap-2 pr-4">
       <ProductComponent
           v-for="product in sortedProducts"
           :key="`${product.product.id}-${product.container.id}`"


### PR DESCRIPTION
# Description
Used VNC to verify that in this setup, the screens in the GEWIS room will now also have 5 columns.
![image](https://github.com/user-attachments/assets/4f32646d-e6a9-46e9-bfe0-4823c09ca34b)


## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_