### PR TITLE
feat(point-of-sale): add `all` category for small POS

### DIFF
--- a/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
+++ b/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleProductsComponent.vue
@@ -56,7 +56,7 @@ const getFilteredProducts = () => {
     }));
   });
 
-  if (props.selectedCategoryId && !props.isProductSearch) {
+  if (props.selectedCategoryId && props.selectedCategoryId !== 'all' && !props.isProductSearch) {
     filteredProducts = filteredProducts.filter((product) => {
       return product.product.category.id === Number(props.selectedCategoryId);
     });
@@ -101,9 +101,19 @@ const sortedProducts = computed(() => {
         return 1;
       }
     }
-      const nameA = a.product.name.toLowerCase();
-      const nameB = b.product.name.toLowerCase();
-      return nameA.localeCompare(nameB);
+
+    // If category is 'all', first also sort by categoryId
+    if (props.selectedCategoryId === 'all') {
+      if (a.product.category.id < b.product.category.id) {
+        return -1;
+      } else if (a.product.category.id > b.product.category.id) {
+        return 1;
+      }
+    }
+
+    const nameA = a.product.name.toLowerCase();
+    const nameB = b.product.name.toLowerCase();
+    return nameA.localeCompare(nameB);
   });
 
   return products;


### PR DESCRIPTION
# Description
The categories do more harm when the amount of products would fit on a single page. The use case is, as seen in the picture, for outside borrels.
![image](https://github.com/user-attachments/assets/be41479c-eb90-41a3-9b76-e4e2cb6de9c7)

## Related issues/external references
#264 

## Types of changes
- New feature _(non-breaking change which adds functionality)_
