### PR TITLE
fix: fetching of pending payouts

### DIFF
--- a/apps/dashboard/src/mixins/pendingPayoutsMixin.ts
+++ b/apps/dashboard/src/mixins/pendingPayoutsMixin.ts
@@ -1,18 +1,25 @@
 // src/mixins/pendingPayoutsMixin.ts
-import { computed, type ComputedRef } from 'vue';
+import { computed, type ComputedRef, watch } from 'vue';
 import { usePayoutStore } from '@/stores/payout.store';
 import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import { UserRole } from '@/utils/rbacUtils';
 
 export function usePendingPayouts() {
   const userStore = useUserStore();
-  let pendingPayouts: ComputedRef<number> | undefined;
+  const payoutStore = usePayoutStore();
+  const pendingPayouts = computed(() => payoutStore.pending);
 
-  if (userStore.current.rolesWithPermissions.findIndex(r => r.name == UserRole.BAC_PM) != -1) {
-    const payoutStore = usePayoutStore();
-    payoutStore.fetchPending();
-    pendingPayouts = computed(() => payoutStore.pending);
+  function updatePendingPayouts() {
+   if (userStore.current.rolesWithPermissions.findIndex(r => r.name == UserRole.BAC_PM) != -1) {
+      const payoutStore = usePayoutStore();
+      payoutStore.fetchPending();
+    }
   }
 
+  watch(() => userStore.current.rolesWithPermissions, () => {
+    updatePendingPayouts();
+  });
+
+  updatePendingPayouts();
   return { pendingPayouts };
 }


### PR DESCRIPTION
# Description
UserStore wasn't mounted when trying to fetch new payouts

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_