### PR TITLE
fix(dashboard/admin): fix pagination jumping back on search queries

### DIFF
--- a/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
@@ -11,7 +11,7 @@
         filterDisplay="menu"
         :globalFilterFields="['type', 'firstName', 'lastName', 'fullName']"
         lazy
-        :totalRecords="sortedUsers.length > 0 ? sortedUsers.length : totalRecords"
+        :totalRecords="searchQuery.split(' ').length > 1 ? sortedUsers.length : totalRecords"
         :loading="isLoading"
         @page="onPage($event)"
         @sort="onSort"


### PR DESCRIPTION
# Description
Fixes issue where whenever searching a name, and going to the last page, it would jump back to the first page.

## Related issues/external references
Closes #310

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
