### PR TITLE
feat(pos/seller-selection): add outline buttons for cashiers

### DIFF
--- a/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectButtonComponent.vue
+++ b/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectButtonComponent.vue
@@ -1,18 +1,22 @@
 <template>
-  <div class="select-user c-btn active square flex-grow-1 fs-6 py-4 px-4" @click="select()">
+  <div
+    class="select-user active square flex-grow-1 fs-6 py-4 px-4"
+    :class="{ 'c-btn': props.associate.type === 'owner', 'c-btn-outline': props.associate.type !== 'owner' }"
+    @click="select()"
+  >
     {{ displayName() }}
   </div>
 </template>
 
 <script setup lang="ts">
-import { UserResponse } from "@sudosos/sudosos-client";
 import { useCartStore } from "@/stores/cart.store";
+import { PointOfSaleAssociate } from "@/stores/pos.store";
 
 const cartStore = useCartStore();
 
 const props = defineProps({
-  member: {
-    type: Object as () => UserResponse,
+  associate: {
+    type: Object as () => PointOfSaleAssociate,
     required: true,
   }
 });
@@ -20,17 +24,17 @@ const props = defineProps({
 const emit = defineEmits(['cancelSelectCreator']);
 
 const displayName = () => {
-  let name = props.member.firstName;
-  if (props.member) {
+  let name = props.associate.firstName;
+  if (props.associate) {
     // @ts-ignore
-    if (props.member.nickname) name += ` "${props.member.nickname}"`;
+    if (props.associate.nickname) name += ` "${props.associate.nickname}"`;
   }
-  name += ' ' + props.member.lastName;
+  name += ' ' + props.associate.lastName;
   return name;
 };
 
 const select = () => {
-  cartStore.setCreatedBy(props.member);
+  cartStore.setCreatedBy(props.associate);
   cartStore.checkout();
   emit('cancelSelectCreator');
 };

--- a/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectionComponent.vue
+++ b/apps/point-of-sale/src/components/BuyerSelect/BuyerSelectionComponent.vue
@@ -11,7 +11,7 @@
       </div>
     </div>
     <div class="flex-container align-content-center justify-content-center flex-wrap w-full h-full gap-3">
-      <BuyerSelectButtonComponent v-for="member in organMembers"  :key="member.id" :member="member"
+      <BuyerSelectButtonComponent v-for="associate in posAssociates"  :key="associate.id" :associate="associate"
                                   @cancel-select-creator="cancelSelect()"/>
     </div>
   </div>
@@ -19,20 +19,19 @@
 
 <script setup lang="ts">
 import { computed, onMounted } from "vue";
-import { usePointOfSaleStore } from "@/stores/pos.store";
+import { PointOfSaleAssociate, usePointOfSaleStore } from "@/stores/pos.store";
 import BuyerSelectButtonComponent from "@/components/BuyerSelect/BuyerSelectButtonComponent.vue";
-import { UserResponse } from "@sudosos/sudosos-client";
 
 const emit = defineEmits(['cancelSelectCreator']);
 
 const posStore = usePointOfSaleStore();
 const currentPos = posStore.getPos;
-const organMembers = computed<UserResponse[] | null>(() => posStore.getPointOfSaleMembers);
+const posAssociates = computed<PointOfSaleAssociate[] | null>(() => posStore.getPointOfSaleAssociates);
 const organName = computed(() => posStore.getPos?.owner?.firstName);
 
 const fetchIfEmpty = () => {
   if (!currentPos || !currentPos.owner) return;
-  if (!organMembers.value) posStore.fetchPointOfSaleMembers(currentPos.owner.id);
+  if (!posAssociates.value) posStore.fetchPointOfSaleAssociates(currentPos.id);
 };
 
 const cancelSelect = () => {

--- a/apps/point-of-sale/src/scss/common.scss
+++ b/apps/point-of-sale/src/scss/common.scss
@@ -161,27 +161,13 @@ input:focus {
 }
 
 /* Custom button styles */
-.c-btn {
+.c-btn-base {
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   border: none;
-  color: var(--accent-color);;
   transition: background-color 0.2s ease-in-out;
-
-  &.active {
-    background-color: var(--accent-color);;
-    color: $text-on-accent;
-
-    > svg {
-      color: $text-on-accent;
-
-      &-large {
-        font-size: $icon-large;
-      }
-    }
-  }
 
   &.icon {
     &-large {
@@ -212,5 +198,28 @@ input:focus {
   &.rounder {
     border-radius: $border-radius-rounder;
     padding: 13px 25px;
+  }
+}
+
+.c-btn-outline {
+  @extend .c-btn-base;
+  border: var(--accent-color) solid 3px;
+}
+
+.c-btn {
+  @extend .c-btn-base;
+  color: var(--accent-color);
+
+  &.active {
+    background-color: var(--accent-color);
+    color: $text-on-accent;
+
+    > svg {
+      color: $text-on-accent;
+
+      &-large {
+        font-size: $icon-large;
+      }
+    }
   }
 }

--- a/apps/point-of-sale/src/stores/cart.store.ts
+++ b/apps/point-of-sale/src/stores/cart.store.ts
@@ -1,10 +1,10 @@
 import { defineStore } from 'pinia';
 import {
+  BaseUserResponse,
   ContainerResponse,
   ProductResponse,
   SubTransactionRequest,
   TransactionRequest,
-  UserResponse
 } from '@sudosos/sudosos-client';
 import { SubTransactionRowRequest } from '@sudosos/sudosos-client/src/api';
 import { usePointOfSaleStore } from '@/stores/pos.store';
@@ -19,9 +19,9 @@ export interface CartProduct {
 
 interface CartState {
   products: CartProduct[]
-  buyer: UserResponse | null
-  createdBy: UserResponse | null
-  lockedIn: UserResponse | null
+  buyer: BaseUserResponse | null
+  createdBy: BaseUserResponse | null
+  lockedIn: BaseUserResponse | null
 }
 export const useCartStore = defineStore('cart', {
   state: (): CartState => ({
@@ -43,18 +43,18 @@ export const useCartStore = defineStore('cart', {
         return total + product.count * productPrice;
       }, 0);
     },
-    getBuyer(): UserResponse | null {
+    getBuyer(): BaseUserResponse | null {
       return this.buyer;
     }
   },
   actions: {
-    setLockedIn(lockedIn: UserResponse | null) {
+    setLockedIn(lockedIn: BaseUserResponse | null) {
       this.lockedIn = lockedIn;
     },
-    setBuyer(buyer: UserResponse | null) {
+    setBuyer(buyer: BaseUserResponse | null) {
       this.buyer = buyer;
     },
-    setCreatedBy(createdBy: UserResponse) {
+    setCreatedBy(createdBy: BaseUserResponse) {
       this.createdBy = createdBy;
     },
     addToCart(cartProduct: CartProduct): void {

--- a/apps/point-of-sale/src/stores/pos.store.ts
+++ b/apps/point-of-sale/src/stores/pos.store.ts
@@ -4,7 +4,7 @@ import {
   PaginatedBaseTransactionResponse, PointOfSaleAssociateUsersResponse,
   PointOfSaleResponse,
   PointOfSaleWithContainersResponse,
-  ProductResponse, UserResponse
+  ProductResponse,
 } from '@sudosos/sudosos-client';
 import apiService from '@/services/ApiService';
 import { fetchAllPages } from "@sudosos/sudosos-frontend-common";

--- a/apps/point-of-sale/src/stores/pos.store.ts
+++ b/apps/point-of-sale/src/stores/pos.store.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import {
-  PaginatedBaseTransactionResponse,
+  BaseUserResponse,
+  PaginatedBaseTransactionResponse, PointOfSaleAssociateUsersResponse,
   PointOfSaleResponse,
   PointOfSaleWithContainersResponse,
   ProductResponse, UserResponse
@@ -8,10 +9,12 @@ import {
 import apiService from '@/services/ApiService';
 import { fetchAllPages } from "@sudosos/sudosos-frontend-common";
 
+export type PointOfSaleAssociate = BaseUserResponse & { type: 'owner' | 'cashier' };
+
 export const usePointOfSaleStore = defineStore('pointOfSale', {
   state: () => ({
     pointOfSale: null as PointOfSaleWithContainersResponse | null,
-    pointOfSaleMembers: null as UserResponse[] | null,
+    pointOfSaleAssociates: null as PointOfSaleAssociateUsersResponse | null,
     usersPointOfSales: null as PointOfSaleResponse[] | null,
   }),
   getters: {
@@ -30,8 +33,18 @@ export const usePointOfSaleStore = defineStore('pointOfSale', {
     getPos(): PointOfSaleWithContainersResponse | null {
       return this.pointOfSale;
     },
-    getPointOfSaleMembers(): UserResponse[] | null {
-      return this.pointOfSaleMembers;
+    getPointOfSaleAssociates(): PointOfSaleAssociate[] | null {
+      if (this.pointOfSaleAssociates == null) return null;
+
+      const owners: PointOfSaleAssociate[] = this.pointOfSaleAssociates.ownerMembers
+        .map((u) => ({ ...u, type: 'owner' }));
+      const cashiers: PointOfSaleAssociate[] = this.pointOfSaleAssociates.cashiers
+        // Owner overrides cashier (so we avoid duplicates)
+        .filter((u1) => !owners.some((u2) => u1.id === u2.id))
+        .map((u) => ({ ...u, type: 'cashier' }));
+
+      const associates = owners.concat(cashiers);
+      return associates.sort((a, b) => a.id - b.id);
     }
   },
   actions: {
@@ -42,12 +55,12 @@ export const usePointOfSaleStore = defineStore('pointOfSale', {
     },
     async fetchPointOfSale(id: number): Promise<void> {
       const response = await apiService.pos.getSinglePointOfSale(id);
-      this.pointOfSaleMembers = null;
+      this.pointOfSaleAssociates = null;
       this.pointOfSale = response.data;
     },
-    async fetchPointOfSaleMembers(organId: number): Promise<void> {
-      const response = await apiService.user.getOrganMembers(organId);
-      this.pointOfSaleMembers = response.data.records;
+    async fetchPointOfSaleAssociates(posId: number): Promise<void> {
+      const response = await apiService.pos.getPointOfSaleAssociates(posId);
+      this.pointOfSaleAssociates = response.data;
     },
     async fetchUserPointOfSale(id: number): Promise<void> {
       this.usersPointOfSales = await fetchAllPages<PointOfSaleResponse>((take, skip) =>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
Adds cashier roles to the screen with all POS owners. They are visually distinguishable by the buttons: POS owners have a solid button, while cashiers have an outlined button. This allows "Feuten" to also create transactions in their own name.

![image](https://github.com/user-attachments/assets/8e94f244-aa5d-4ca4-9c40-aa8c04f5ca34)
## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
POS implementation of https://github.com/GEWIS/sudosos-backend/pull/222. Note that the dashboard implementation is still missing. However, this (probably) has less priority, as you only need to set the cashier roles once.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_