### PR TITLE
fix(pos): balance not changing when locking buyer

### DIFF
--- a/apps/point-of-sale/src/components/Cart/CartComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartComponent.vue
@@ -148,13 +148,6 @@ watch(shouldShowTransactions, () => {
 
 watch(
   () => cartStore.buyer,
-  async () => {
-    balance.value = await getBalance();
-  }
-);
-
-watch(
-  () => cartStore.buyer,
   () => {
     if (shouldShowTransactions.value) getUserRecentTransactions();
   }

--- a/apps/point-of-sale/src/components/Cart/CartComponent.vue
+++ b/apps/point-of-sale/src/components/Cart/CartComponent.vue
@@ -23,7 +23,7 @@
         <div class="font-bold font-size-lg">€{{ formatPrice(totalPrice) }}</div>
       </div>
       <div class="font-size-md pt-2 align-items-end flex-container justify-content-between"
-           v-if="balance">
+           v-if="cartStore.buyerBalance != null">
         <span><i
           class="pi pi-exclamation-triangle"/> Debit after purchase: </span>
         €{{ formattedBalanceAfter }}
@@ -61,7 +61,6 @@ const current = computed(() => cartStore.getBuyer);
 const totalPrice = computed(() => cartStore.getTotalPrice);
 const shouldShowTransactions = computed(() => cartStore.cartTotalCount === 0);
 const showHistory = ref(true);
-const balance = ref<number | null>(null);
 
 const { pointOfSale } = storeToRefs(posStore);
 const { lockedIn } = storeToRefs(cartStore);
@@ -94,16 +93,6 @@ const getPointOfSaleRecentTransactions = () => {
   posStore.fetchRecentPosTransactions().then((res) => {
     if (res) transactions.value.push(...res.records);
   });
-};
-
-const getBalance = async () => {
-  if (!cartStore.buyer) return 0;
-  try {
-    const response = await apiService.balance.getBalanceId(cartStore.buyer.id);
-    return response.data.amount.amount;
-  } catch (error) {
-    return null;
-  }
 };
 
 const isOwnBuyer = computed(() => {
@@ -146,7 +135,6 @@ const showLock = () => {
 };
 
 onMounted(async () => {
-  balance.value = await getBalance();
   if (shouldShowTransactions.value) getUserRecentTransactions();
 });
 
@@ -157,13 +145,6 @@ watch(cartItems, () => {
 watch(shouldShowTransactions, () => {
   if (shouldShowTransactions.value) getUserRecentTransactions();
 });
-
-watch(
-  () => cartStore.buyer,
-  async () => {
-    balance.value = await getBalance();
-  }
-);
 
 let refreshRecentPosTransactions: number | null;
 
@@ -197,8 +178,8 @@ const selectUser = () => {
 };
 
 const formattedBalanceAfter = computed(() => {
-  if (!balance.value) return null;
-  const price = balance.value - totalPrice.value;
+  if (cartStore.buyerBalance == null) return null;
+  const price = cartStore.buyerBalance.amount - totalPrice.value;
   return formatPrice(price);
 });
 

--- a/apps/point-of-sale/src/services/PointOfSaleSwitchService.ts
+++ b/apps/point-of-sale/src/services/PointOfSaleSwitchService.ts
@@ -25,7 +25,7 @@ export class PointOfSaleSwitchService {
 
       // Switch buyer back to user if authentication
       const cartStore = useCartStore();
-      cartStore.setBuyer(target.useAuthentication ? useAuthStore().getUser : null);
+      cartStore.setBuyer(target.useAuthentication ? useAuthStore().getUser : null).then(() => {});
       cartStore.setLockedIn(null);
 
       target.useAuthentication ? activityStore.resetTimer() : activityStore.disableTimer();

--- a/apps/point-of-sale/src/stores/cart.store.ts
+++ b/apps/point-of-sale/src/stores/cart.store.ts
@@ -29,6 +29,7 @@ export const useCartStore = defineStore('cart', {
   state: (): CartState => ({
     products: [] as CartProduct[],
     buyer: null,
+    buyerBalance: null,
     createdBy: null,
     lockedIn: null,
   }),

--- a/apps/point-of-sale/src/views/LoginView.vue
+++ b/apps/point-of-sale/src/views/LoginView.vue
@@ -122,7 +122,7 @@ const loginSucces = async () => {
   if (user === null) return;
 
   if (userStore.getActiveUsers.length === 0) await userStore.fetchUsers;
-  useCartStore().setBuyer(user);
+  await useCartStore().setBuyer(user);
   userStore.fetchCurrentUserBalance(user.id, apiService);
 
   await router.push({ path: '/cashier' });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
When locking in a user in borrel mode (for example an invoice account), the user's balance is never updated after each transaction. The manual fix is to reselect the user, but this PR will automatically update the user's balance after every transaction.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_