### PR TITLE
feat(pos-display): Alcohol time warning

### DIFF
--- a/apps/point-of-sale/package.json
+++ b/apps/point-of-sale/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "point-of-sale:dev": "yarn dev",
     "dev-host": "vite --host",
     "build": "run-p type-check build-only",
     "preview": "vite preview",

--- a/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleDisplayComponent.vue
+++ b/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleDisplayComponent.vue
@@ -34,6 +34,11 @@
       </div>
       </div>
     </div>
+    <Message v-if="isCategoryAlcoholic && !useSettingStore().isAlcoholTime" severity="warn" class="mr-4">
+      Please note that today, alcoholic drinks are only allowed to be served after
+      {{ new Date(useSettingStore().alcoholTimeToday).toLocaleTimeString('nl-NL') }}.
+      This also applies to non-alcoholic alternatives on this page.
+    </Message>
     <PointOfSaleProductsComponent
         :search-query="searchQuery"
         :is-product-search="isSearchViewVisible"
@@ -100,6 +105,11 @@ function getDefaultCategoryId(): string | undefined {
   if (shouldShowAllCategory.value) return 'all';
   return nonAlcoholicCategory ? nonAlcoholicCategory.id : undefined;
 }
+
+const isCategoryAlcoholic = computed(() => {
+  const category = computedCategories.value.find((c) => c.id == selectedCategoryId.value)!;
+  return category.name == 'Alcoholic';
+});
 
 const selectCategory = (categoryId: string) => {
   selectedCategoryId.value = categoryId;

--- a/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleDisplayComponent.vue
+++ b/apps/point-of-sale/src/components/PointOfSaleDisplay/PointOfSaleDisplayComponent.vue
@@ -36,7 +36,7 @@
     </div>
     <Message v-if="isCategoryAlcoholic && !useSettingStore().isAlcoholTime" severity="warn" class="mr-4">
       Please note that today, alcoholic drinks are only allowed to be served after
-      {{ new Date(useSettingStore().alcoholTimeToday).toLocaleTimeString('nl-NL') }}.
+      {{ new Date(useSettingStore().alcoholTimeToday).toLocaleTimeString('nl-NL', { hour: "2-digit", minute: "2-digit" }) }}.
       This also applies to non-alcoholic alternatives on this page.
     </Message>
     <PointOfSaleProductsComponent

--- a/apps/point-of-sale/src/main.ts
+++ b/apps/point-of-sale/src/main.ts
@@ -16,6 +16,7 @@ import Dropdown from "primevue/dropdown";
 
 import router from './router';
 import App from './App.vue';
+import { useSettingStore } from "@/stores/settings.store";
 
 const app = createApp(App);
 
@@ -35,3 +36,6 @@ app.component('Dropdown', Dropdown);
 
 app.use(createPinia());
 app.mount('#app');
+useSettingStore().fetchAlcoholTimeToday();
+
+

--- a/apps/point-of-sale/src/main.ts
+++ b/apps/point-of-sale/src/main.ts
@@ -17,6 +17,7 @@ import Dropdown from "primevue/dropdown";
 import router from './router';
 import App from './App.vue';
 import { useSettingStore } from "@/stores/settings.store";
+import Message from "primevue/message";
 
 const app = createApp(App);
 
@@ -33,6 +34,8 @@ app.component('Panel', Panel);
 app.component('OverlayPanel', OverlayPanel);
 // eslint-disable-next-line
 app.component('Dropdown', Dropdown);
+// eslint-disable-next-line
+app.component('Message', Message);
 
 app.use(createPinia());
 app.mount('#app');

--- a/apps/point-of-sale/src/scss/base.scss
+++ b/apps/point-of-sale/src/scss/base.scss
@@ -59,6 +59,5 @@
 *::before,
 *::after {
   box-sizing: border-box;
-  margin: 0;
   font-weight: normal;
 }

--- a/apps/point-of-sale/src/stores/settings.store.ts
+++ b/apps/point-of-sale/src/stores/settings.store.ts
@@ -4,7 +4,7 @@ import { usePointOfSaleStore } from "@/stores/pos.store";
 
 export const useSettingStore = defineStore('setting', {
   state: () => ({
-    alcoholTimeToday: Date.now()+24*60*60*1000,
+    alcoholTimeToday: Date.now()+24*60*60*1000, // Should always be recalculated
   }),
   getters: {
     isAuthenticatedPos(): boolean {
@@ -24,11 +24,14 @@ export const useSettingStore = defineStore('setting', {
     showAddToCartAnimation(): boolean {
       return this.isAuthenticatedPos;
     },
+    isAlcoholTime(): boolean {
+      return Date.now() >= this.alcoholTimeToday;
+    },
     getTargetCategory(): string {
       if (this.isBorrelmode) {
         return 'alcoholic';
       } else {
-        return Date.now() >= this.alcoholTimeToday ? 'alcoholic' : 'non-alcoholic';
+        return this.isAlcoholTime ? 'alcoholic' : 'non-alcoholic';
       }
     }
   },
@@ -44,6 +47,7 @@ export const useSettingStore = defineStore('setting', {
       const date = new Date().toISOString().split('T')[0];
       const alcTimeRes = await fetch('https://infoscherm.gewis.nl/backoffice/api.php?query=alcoholtijd');
 
+      // Default alcohol time is 16:30
       let alcTime = "16:30";
 
       if(alcTimeRes.ok) {

--- a/apps/point-of-sale/src/stores/settings.store.ts
+++ b/apps/point-of-sale/src/stores/settings.store.ts
@@ -54,9 +54,12 @@ export const useSettingStore = defineStore('setting', {
           alcTime = alcTimeResText;
         }
       }
-      console.log(`${date}T${alcTime}:00.000-0${new Date().getTimezoneOffset()/-60}:00`);
-      this.alcoholTimeToday = Date.parse(`${date}T${alcTime}:00.000+0${new Date().getTimezoneOffset()/-60}:00`);
-      console.log(new Date(this.alcoholTimeToday));
+
+      // This code only works for timezones that are whole hours apart from UTC.
+      // Do not deploy SudoSOS POS in some parts of India, Australia and other countries.
+      const timezoneOffset = new Date().getTimezoneOffset()*60*1000;
+      this.alcoholTimeToday = Date.parse(`${date}T${alcTime}:00.000Z`)+timezoneOffset;
+      console.log(this.alcoholTimeToday);
       return this.alcoholTimeToday;
     }
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "dev-libraries": "concurrently --kill-others \"yarn common:dev\"",
         "dev-dashboard": "concurrently --kill-others \"yarn dashboard:dev\" \"yarn dev-libraries\"",
-        "dev-pos": "concurrently --kill-others \"yarn dashboard:dev\" \"yarn common:dev\"",
+        "dev-pos": "concurrently --kill-others \"yarn point-of-sale:dev\" \"yarn dev-libraries\"",
         "build-libraries": "yarn workspace common run build",
         "build-dashboard": "yarn workspaces foreach -Rpt --from 'sudosos-dashboard' run build",
         "build-pos": "yarn workspaces foreach -Rpt --from 'sudosos-point-of-sale' run build"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
Uses the backoffice api to fetch alcohol time and display if the user is on the alcoholic tab.

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
![image](https://github.com/user-attachments/assets/04e29a43-850a-4970-954d-9cb7abcf3336)
Warning on alcoholic tab, now also switches to alcoholic tab based on the backoffice api. If the request should fail the fallback is 16:30. 

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
#322 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_

