### PR TITLE
fix: flagged transaction email is cut off

### DIFF
--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -3,6 +3,7 @@ VITE_APP_IMAGE_BASE='https://sudosos.test.gewis.nl/static/'
 VITE_APP_GEWIS_TOKEN=sudosos-dev
 VITE_APP_STRIPE_PUBLISHABLE_KEY='pk_test_51GsQ83CTbnWP3CTYRobkOgrA4EjkHqvAN6FpDCccxfXayLzj4prFU0GeMIefYW0pvdwXuXqpmqJVLnf6bUyvNJ2T009bK0Sn1L'
 VITE_APP_STRIPE_RETURN_URL='http://localhost:5173/'
+VITE_APP_TREASURER_EMAIL='test@test.com'
 VITE_GIT_COMMIT_BRANCH=''
 VITE_GIT_COMMIT_SHA=''
 # Where the local api requests should be proxied to

--- a/apps/dashboard/src/utils/mailUtil.ts
+++ b/apps/dashboard/src/utils/mailUtil.ts
@@ -4,9 +4,9 @@ import { formatPrice } from '@/utils/formatterUtils';
 
 export function sendEmail(transactionInfo: TransactionResponse, productsInfo: Array<SubTransactionRowResponse>)
 {
-  window.open("mailto:" + encodeURIComponent(getEmail())
-    + "?subject=" + encodeURIComponent(getSubject(transactionInfo))
-    + "&body="+ encodeURIComponent(getBody(transactionInfo, productsInfo)));
+  window.open(`mailto:${getEmail()}
+  ?subject=${getSubject(transactionInfo)}
+  &body=${getBody(transactionInfo, productsInfo)}`);
 }
 
 function getEmail(): string {
@@ -14,14 +14,14 @@ function getEmail(): string {
 }
 
 function getSubject(transactionInfo: TransactionResponse): string {
-  return "[FLAGGED TRANSACTION] "
+  return encodeURIComponent("[FLAGGED TRANSACTION] "
     + transactionInfo.from.firstName + " "
     + transactionInfo.from.lastName + " "
-    + getTime(transactionInfo);
+    + getTime(transactionInfo));
 }
 
 function getBody(transactionInfo: TransactionResponse, productsInfo: Array<SubTransactionRowResponse>): string {
-  return "Transaction Id: " + transactionInfo.id +  "\n"
+  return encodeURIComponent("Transaction Id: " + transactionInfo.id +  "\n"
     + "Transaction for: " + transactionInfo.from.firstName + " "
       + transactionInfo.from.lastName + " (" + transactionInfo.from.id + ")\n"
     + "Transaction by: " + transactionInfo.createdBy!.firstName
@@ -31,7 +31,7 @@ function getBody(transactionInfo: TransactionResponse, productsInfo: Array<SubTr
     + formatProducts(productsInfo)
     + "________________________\n"
     + "DO NOT CHANGE ANY OF THE ABOVE INFO\n"
-    + "Please add any additional information below:\n";
+    + "Please add any additional information below:\n");
 }
 
 function getTime(transactionInfo: TransactionResponse): string {

--- a/apps/dashboard/src/utils/mailUtil.ts
+++ b/apps/dashboard/src/utils/mailUtil.ts
@@ -4,9 +4,9 @@ import { formatPrice } from '@/utils/formatterUtils';
 
 export function sendEmail(transactionInfo: TransactionResponse, productsInfo: Array<SubTransactionRowResponse>)
 {
-  window.open("mailto:" + getEmail()
-    + "?subject=" + getSubject(transactionInfo)
-    + "&body="+ getBody(transactionInfo, productsInfo));
+  window.open("mailto:" + encodeURIComponent(getEmail())
+    + "?subject=" + encodeURIComponent(getSubject(transactionInfo))
+    + "&body="+ encodeURIComponent(getBody(transactionInfo, productsInfo)));
 }
 
 function getEmail(): string {
@@ -21,16 +21,17 @@ function getSubject(transactionInfo: TransactionResponse): string {
 }
 
 function getBody(transactionInfo: TransactionResponse, productsInfo: Array<SubTransactionRowResponse>): string {
-  return "Transaction Id: " + transactionInfo.id +  "%0D%0A"
+  return "Transaction Id: " + transactionInfo.id +  "\n"
     + "Transaction for: " + transactionInfo.from.firstName + " "
-      + transactionInfo.from.lastName + " (" + transactionInfo.from.id + ")%0D%0A"
+      + transactionInfo.from.lastName + " (" + transactionInfo.from.id + ")\n"
     + "Transaction by: " + transactionInfo.createdBy!.firstName
-      + " " + transactionInfo.createdBy!.lastName + " (" + transactionInfo.createdBy!.id + ")%0D%0A"
-    + "Transaction at: " + transactionInfo.pointOfSale.name + "%0D%0A"
-    + "%0D%0AProducts in transaction: " + "%0D%0A" + formatProducts(productsInfo)
-    + "________________________%0D%0A"
-    + "DO NOT CHANGE ANY OF THE ABOVE INFO%0D%0A"
-    + "Please add any additional information below:%0D%0A";
+      + " " + transactionInfo.createdBy!.lastName + " (" + transactionInfo.createdBy!.id + ")\n"
+    + "Transaction at: " + transactionInfo.pointOfSale.name + "\n"
+    + "\nProducts in transaction: \n"
+    + formatProducts(productsInfo)
+    + "________________________\n"
+    + "DO NOT CHANGE ANY OF THE ABOVE INFO\n"
+    + "Please add any additional information below:\n";
 }
 
 function getTime(transactionInfo: TransactionResponse): string {
@@ -47,7 +48,7 @@ function formatProducts(productsInfo: Array<SubTransactionRowResponse>): string 
     returnString +=  product.amount + "x "
       + product.product.name + " @ "
       + formatPrice(product.product.priceInclVat) + " = "
-      + formatPrice(product.totalPriceInclVat) + "%0D%0A";
+      + formatPrice(product.totalPriceInclVat) + "\n";
   });
 
   return returnString;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
I have found an issue related to the "Did you not make this transaction?" button, added in #363 (Oops... 😅)
If you press this button on mobile and open the link in the Gmail app, the mail body that is passed in the link is cut off.

This results in the template looking like this:
![image](https://github.com/user-attachments/assets/4991bd21-2de8-4446-b347-4998166fe360)

I have changed the encoding for the `mailto` link which results in the mail template looking like this (As expected):
![image](https://github.com/user-attachments/assets/5ae2a1e8-3193-494a-8a5e-7a68dc587ef3)


# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
#360 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
