### PR TITLE
fix: remove topup warning on landing page

### DIFF
--- a/apps/dashboard/src/modules/user/views/UserLandingView.vue
+++ b/apps/dashboard/src/modules/user/views/UserLandingView.vue
@@ -2,14 +2,6 @@
   <div class="page-container flex flex-column">
     <div class="page-title">{{ t('modules.user.landing.title') }}</div>
     <div class="content-wrapper gap-5 flex md:flex-column flex-column">
-      <Message v-if="true" severity="warn" class="w-full">
-        <i18n-t keypath="modules.user.landing.motd" tag="label">
-          <template v-slot:link>
-            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text  -->
-            <a href="https://gew.is/failedtopup" target="_blank" rel="noopener noreferrer">gew.is/failedtopup</a>
-          </template>
-        </i18n-t>
-      </Message>
       <UserInfo :user="gewisUser || authStore.user as GewisUserResponse" class="md:hidden"/>
       <BalanceWithTopupComponent />
       <MutationsBalanceCard


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
After @tomudding his fix for #435 with PR #436 I think its fine to remove the warning. I also thought about changing the text, but people don't read the message anymore since it has been there for quite a while. Removing it will be the clearest message, and will most likely entice people to let us known if it still fails.

## Related issues/external references


## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
