### PR TITLE
Fix stripe key being used as an object instead of a string.

### DIFF
--- a/apps/dashboard/src/stores/settings.store.ts
+++ b/apps/dashboard/src/stores/settings.store.ts
@@ -22,7 +22,7 @@ export const useSettingsStore = defineStore('settings', {
     },
     async fetchStripe(){
       await apiService.stripe.getStripePublicKey().then((res) =>{
-        this.stripe = res.data;
+        this.stripe = (res.data as any).publicKey as string;
       });
     },
     async fetchKeys(){


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
The backend returns an object `{publicKey: value}` but the swagger says its just `value`. The spec should also be fixend in the backend.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
