### PR TITLE
Remove build step of pos-ab

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        app: [ dashboard, point-of-sale, point-of-sale-ab]
+        app: [ dashboard, point-of-sale ]
         include:
           - app: dashboard
             env_file_main: ${{ vars.ENV_FILE_PRODUCTION }}
@@ -30,13 +30,6 @@ jobs:
             docker_tag: ${{ vars.DOCKER_TAG_POS }}
             dockerfile_path: "apps/point-of-sale/Dockerfile"
             dir: "point-of-sale"
-          - app: point-of-sale-ab
-            env_file_main: ${{ vars.ENV_FILE_PRODUCTION }}
-            env_file_develop: ${{ vars.ENV_FILE_PRODUCTION }}
-            docker_tag: ${{ vars.DOCKER_TAG_POS }}-ab
-            dockerfile_path: "apps/point-of-sale/Dockerfile"
-            dir: "point-of-sale"
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
No longer needed as the pos (and dashboard) now use the backend found via the root url to determine variables.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
- CI/CD _(Changes to the CI/CD configuration)_
