### PR TITLE
Use store to get API key of user and admins can request to change

### DIFF
--- a/apps/dashboard/src/modules/user/components/UserSettingsComponent.vue
+++ b/apps/dashboard/src/modules/user/components/UserSettingsComponent.vue
@@ -87,6 +87,7 @@ import { useConfirm } from "primevue/useconfirm";
 import { useToast } from "primevue/usetoast";
 import apiService from "@/services/ApiService";
 import { handleError } from "@/utils/errorUtils";
+import { useUserStore } from "@sudosos/sudosos-frontend-common";
 
 async function startScan() {
   if (!('NDEFReader' in window)) {
@@ -151,6 +152,7 @@ const editPin = ref(true);
 const confirm = useConfirm();
 const toast = useToast();
 const dataAnalysis = ref(props.user.extensiveDataProcessing);
+const userStore = useUserStore();
 
 const handleChangeDataAnalysis = (value: boolean) => {
   apiService.user.updateUser(props.user.id, { extensiveDataProcessing: value })
@@ -174,7 +176,7 @@ const confirmChangeApiKey = () => {
     header: t('modules.user.settings.changeApiKey'),
     icon: 'pi pi-exclamation-triangle',
     accept: () => {
-      apiService.user.updateUserKey(props.user.id)
+      userStore.fetchUserApi(apiService, props.user.id)
           .then((res) => {
             toast.add({
               severity: "success",

--- a/lib/common/src/stores/user.store.ts
+++ b/lib/common/src/stores/user.store.ts
@@ -125,6 +125,9 @@ export const useUserStore = defineStore('user', {
         return res.data as GewisUserResponse;
       });
     },
+    async fetchUserApi(service: ApiService, id: number){
+      return (await service.user.updateUserKey(id));
+    },
     async waiveUserFine(id: number, amount: DineroObjectRequest, service: ApiService) {
       return service.user.waiveUserFines(id, {
         amount


### PR DESCRIPTION
# Description
The change can be requested on others' pages in the user overview.

Admins can now change the users' API key from the user overview.

We now use the store of users to change the API key of users and Admins can do it on the users' overview.

## Related issues/external references
Fixes#268 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_

