### PR TITLE
fix(dashboard): Deselecting active filter shows active and inactive user

### DIFF
--- a/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
@@ -196,7 +196,7 @@ const apiCall: (skip: number) => Promise<void> = async (skip: number) => {
           DEFAULT_PAGINATION_MAX,
           skip,
           searchQuery.value.split(' ')[0] || '',
-          isActiveFilter.value,
+          isActiveFilter.value ? isActiveFilter.value : undefined,
           ofAgeFilter.value,
           undefined,
           filters.value.type.value || undefined
@@ -205,22 +205,6 @@ const apiCall: (skip: number) => Promise<void> = async (skip: number) => {
         totalRecords.value = response.data._pagination.count || 0;
         allUsers.value = response.data.records;
       });
-  if ( !isActiveFilter.value ){
-    await apiService.user
-        .getAllUsers(
-            DEFAULT_PAGINATION_MAX,
-            skip,
-            searchQuery.value.split(' ')[0] || '',
-            !isActiveFilter.value,
-            ofAgeFilter.value,
-            undefined,
-            filters.value.type.value || undefined
-        )
-        .then((response) => {
-          totalRecords.value += (response.data._pagination.count || 0);
-          allUsers.value = allUsers.value.concat(response.data.records);
-        });
-  }
 };
 
 const delayedAPICall = debounce(apiCall, 250);

--- a/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
@@ -191,19 +191,35 @@ function debounce(func: (skip: number) => Promise<void>, delay: number): (skip: 
 
 const apiCall: (skip: number) => Promise<void> = async (skip: number) => {
   await apiService.user
-    .getAllUsers(
-      Number.MAX_SAFE_INTEGER,
-      skip,
-      searchQuery.value.split(' ')[0] || '',
-      isActiveFilter.value,
-      ofAgeFilter.value,
-      undefined,
-      filters.value.type.value || undefined
-    )
-    .then((response) => {
-      totalRecords.value = response.data._pagination.count || 0;
-      allUsers.value = response.data.records;
-    });
+      .getAllUsers(
+          Number.MAX_SAFE_INTEGER,
+          skip,
+          searchQuery.value.split(' ')[0] || '',
+          isActiveFilter.value,
+          ofAgeFilter.value,
+          undefined,
+          filters.value.type.value || undefined
+      )
+      .then((response) => {
+        totalRecords.value = response.data._pagination.count || 0;
+        allUsers.value = response.data.records;
+      });
+  if ( !isActiveFilter.value ){
+    await apiService.user
+        .getAllUsers(
+            Number.MAX_SAFE_INTEGER,
+            skip,
+            searchQuery.value.split(' ')[0] || '',
+            !isActiveFilter.value,
+            ofAgeFilter.value,
+            undefined,
+            filters.value.type.value || undefined
+        )
+        .then((response) => {
+          totalRecords.value += (response.data._pagination.count || 0);
+          allUsers.value = allUsers.value.concat(response.data.records);
+        });
+  }
 };
 
 const delayedAPICall = debounce(apiCall, 250);

--- a/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminUserOverView.vue
@@ -123,6 +123,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, type Ref, watch } from "vue";
 import apiService from '@/services/ApiService';
+import { DEFAULT_PAGINATION_MAX } from '@/services/ApiService';
 import type { GewisUserResponse, UserResponse } from "@sudosos/sudosos-client";
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
@@ -192,7 +193,7 @@ function debounce(func: (skip: number) => Promise<void>, delay: number): (skip: 
 const apiCall: (skip: number) => Promise<void> = async (skip: number) => {
   await apiService.user
       .getAllUsers(
-          Number.MAX_SAFE_INTEGER,
+          DEFAULT_PAGINATION_MAX,
           skip,
           searchQuery.value.split(' ')[0] || '',
           isActiveFilter.value,
@@ -207,7 +208,7 @@ const apiCall: (skip: number) => Promise<void> = async (skip: number) => {
   if ( !isActiveFilter.value ){
     await apiService.user
         .getAllUsers(
-            Number.MAX_SAFE_INTEGER,
+            DEFAULT_PAGINATION_MAX,
             skip,
             searchQuery.value.split(' ')[0] || '',
             !isActiveFilter.value,

--- a/apps/dashboard/src/services/ApiService.ts
+++ b/apps/dashboard/src/services/ApiService.ts
@@ -1,3 +1,5 @@
 import { ApiService } from "@sudosos/sudosos-frontend-common";
 const apiService = new ApiService(window.location.origin + "/api/v1");
 export default apiService;
+
+export const DEFAULT_PAGINATION_MAX = 500;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Now when a user deselects the active filter it both shows the active and inactive members.

## Related issues/external references
Fixes#122 

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_

