### PR TITLE
Fix bug where container create dialog would not close

### DIFF
--- a/apps/dashboard/src/components/container/ContainerActionsDialog.vue
+++ b/apps/dashboard/src/components/container/ContainerActionsDialog.vue
@@ -105,6 +105,7 @@ setSubmit(form, form.context.handleSubmit(async (values) => {
             detail: t('common.toast.success.containerCreated'),
             life: 3000,
           });
+          closeDialog();
         })
         .catch((err) => handleError(err, toast));
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Dialog now closes after creating a container.

## Related issues/external references
#483 

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_