### PR TITLE
feature(dashboard): add transaction id to header

### DIFF
--- a/apps/dashboard/src/components/mutations/mutationmodal/ModalMutation.vue
+++ b/apps/dashboard/src/components/mutations/mutationmodal/ModalMutation.vue
@@ -3,7 +3,7 @@
     @show="addListenerOnDialogueOverlay(dialog)"
     :visible="visible"
     modal
-    :header="t('components.mutations.modal.header')"
+    :header="t('components.mutations.modal.header', {id} )"
     class="w-auto flex w-11 md:w-4"
     ref="dialog"
   >

--- a/apps/dashboard/src/locales/en/components/mutations.json
+++ b/apps/dashboard/src/locales/en/components/mutations.json
@@ -14,7 +14,7 @@
       "user": "User transactions",
       "notYou": "Did you not make this transaction?",
       "modal": {
-        "header": "Transaction details",
+        "header": "Transaction details (#{id})",
         "waivedFine": "Waived fine",
         "invoice": "Invoice",
         "fine": "Fine",

--- a/apps/dashboard/src/locales/nl/components/mutations.json
+++ b/apps/dashboard/src/locales/nl/components/mutations.json
@@ -14,7 +14,7 @@
       "user": "Gebruikerstransacties",
       "notYou": "Heb jij deze aankoop niet gedaan?",
       "modal": {
-        "header": "Transactiedetails",
+        "header": "Transactiedetails (#{id})",
         "waivedFine": "Kwijtgescholden boete",
         "invoice": "Factuur",
         "fine": "Boete",


### PR DESCRIPTION
adds transaction id to header so the BACpm does not have to open mail to see the id

<!-- Provide a general summary of your changes in the title above. -->

# Description
Adds transaction id to header.

## Related issues/external references


## Types of changes
- New feature _(non-breaking change which adds functionality)_
