### PR TITLE
feat(dashboard/financial): improve invoice table by grouping per year instead of state

### DIFF
--- a/apps/dashboard/src/modules/financial/components/invoice/InvoiceTable.vue
+++ b/apps/dashboard/src/modules/financial/components/invoice/InvoiceTable.vue
@@ -4,65 +4,102 @@
         :rows="rows"
         :value="invoices"
         :rows-per-page-options="[5, 10, 25, 50, 100]"
-        :paginator="paginator"
+        :paginator="true"
         lazy
-        @page="onPage($event)"
+        @page="onPage"
         :total-records="totalRecords"
+        :filters="filters"
         data-key="id"
         class="w-full"
         tableStyle="min-width: 50rem"
+        filterDisplay="menu"
     >
       <Column field="date" :header="t('common.date')">
         <template #body="slotProps">
-          <Skeleton v-if="isLoading" class="w-6 my-1 h-1rem surface-300" />
-          <span v-else>
-                        {{ formatDateFromString(slotProps.data.createdAt) }}
-                    </span>
+          <div class="cell-content">
+            <Skeleton v-if="isLoading" class="skeleton-fixed w-6 surface-300" />
+            <span v-else>
+              {{ formatDateFromString(slotProps.data.createdAt) }}
+            </span>
+          </div>
         </template>
       </Column>
-      <Column field="currentState.state" :header="t('common.status')">
+
+      <Column
+          field="currentState.state"
+          :header="t('common.status')"
+          filter
+          filterMatchMode="equals"
+          :showFilterMatchModes="false"
+          :showApplyButton="false"
+          :showClearButton="false"
+      >
+        <template #filter="{ filterModel }">
+          <Dropdown
+              v-model="filterModel.value"
+              @change="stateFilterChange"
+              :options="states"
+              optionLabel="name"
+              optionValue="value"
+              :placeholder="t('common.placeholders.selectType')"
+          />
+        </template>
         <template #body="slotProps">
-          <Skeleton v-if="isLoading" class="w-6 my-1 h-1rem surface-300" />
-          <span v-else>
-                        {{ slotProps.data.currentState.state }}
-                    </span>
+          <div class="cell-content">
+            <Skeleton v-if="isLoading" class="skeleton-fixed w-6 surface-300" />
+            <span v-else>
+              {{ slotProps.data.currentState.state }}
+            </span>
+          </div>
         </template>
       </Column>
-      <Column field="to.firstName" :header="t('common.for')">
+
+      <Column field="to.firstName" :header="t('common.for')" style="max-width: 10rem;">
         <template #body="slotProps">
-          <Skeleton v-if="isLoading" class="w-6 my-1 h-1rem surface-300" />
-          <span v-else>
-                        {{ slotProps.data.to.firstName }}
-                    </span>
+          <div class="cell-content">
+            <Skeleton v-if="isLoading" class="skeleton-fixed w-6 surface-300" />
+            <span v-else class="truncate">
+              {{ slotProps.data.to.firstName }}
+            </span>
+          </div>
         </template>
       </Column>
-      <Column field="description" :header="t('common.description')" style="max-width: 15rem">
+
+      <Column field="description" :header="t('common.description')" style="max-width: 15rem;">
         <template #body="slotProps">
-          <Skeleton v-if="isLoading" class="w-6 my-1 h-1rem surface-300" />
-          <span v-else>
-                        {{ slotProps.data.description }}
-                    </span>
+          <div class="cell-content">
+            <Skeleton v-if="isLoading" class="skeleton-fixed w-6 surface-300" />
+            <span v-else class="truncate">
+              {{ slotProps.data.description }}
+            </span>
+          </div>
         </template>
       </Column>
+
       <Column field="transfer.amount" :header="t('common.amount')">
         <template #body="slotProps">
-          <Skeleton v-if="isLoading" class="w-3 my-1 h-1rem surface-300" />
-          <span v-else>
-                        {{ formatPrice(slotProps.data.transfer?.amount) }}
-                    </span>
+          <div class="cell-content">
+            <Skeleton v-if="isLoading" class="skeleton-fixed w-3 surface-300" />
+            <span v-else>
+              {{ formatPrice(slotProps.data.transfer?.amount) }}
+            </span>
+          </div>
         </template>
       </Column>
+
       <Column :header="t('common.actions')" style="width: 10%">
         <template #body="slotProps">
-          <Skeleton v-if="isLoading" class="w-3 my-1 h-1rem surface-300" />
-          <span v-else>
-                        <Button
-                            type="button"
-                            icon="pi pi-eye"
-                            class="p-button-rounded p-button-text p-button-plain"
-                            @click="() => viewInvoice(slotProps.data.id)"
-                        />
-                    </span>
+          <div class="cell-content">
+            <Skeleton v-if="isLoading" class="skeleton-fixed w-3 surface-300" />
+            <span v-else>
+              <Button
+                  type="button"
+                  icon="pi pi-eye"
+                  class="p-button-rounded p-button-text p-button-plain"
+                  @click="() => viewInvoice(slotProps.data.id)"
+              />
+            </span>
+          </div>
         </template>
       </Column>
     </DataTable>
@@ -70,58 +107,87 @@
 </template>
 
 <script setup lang="ts">
-import DataTable, { type DataTablePageEvent } from 'primevue/datatable';
+import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
-import { ref, onMounted, type PropType } from "vue";
-import { useInvoiceStore } from "@/stores/invoice.store";
+import Skeleton from 'primevue/skeleton';
+import Button from 'primevue/button';
+import Dropdown from 'primevue/dropdown';
+import { useI18n } from 'vue-i18n';
 import { formatPrice, formatDateFromString } from "@/utils/formatterUtils";
-import type { InvoiceResponse } from "@sudosos/sudosos-client";
-import { InvoiceStatusResponseStateEnum } from "@sudosos/sudosos-client/src/api";
 import router from "@/router";
-import { useI18n } from "vue-i18n";
+import { InvoiceStatusResponseStateEnum } from "@sudosos/sudosos-client/src/api";
+import { type Ref, ref } from "vue";
+
+const props = defineProps({
+  invoices: {
+    type: Array,
+    required: true
+  },
+  totalRecords: {
+    type: Number,
+    required: true
+  },
+  isLoading: {
+    type: Boolean,
+    required: true
+  },
+  rows: {
+    type: Number,
+    required: true
+  }
+});
+
+const emit = defineEmits(['page', 'stateFilterChange']);
 
 const { t } = useI18n();
 
-const invoiceStore = useInvoiceStore();
-const totalRecords = ref<number>(0);
-const isLoading = ref<boolean>(true);
+function onPage(event: any) {
+  emit('page', event);
+}
 
-const invoices = ref<InvoiceResponse[]>([]);
+function stateFilterChange(e: any) {
+  console.log(e);
+  emit('stateFilterChange', e);
+}
 
-const rows = ref<number>(10);
-const paginator = ref<boolean>(true);
+const states: Ref<Array<{name: string, value: string | null}>> = ref([
+  { name: InvoiceStatusResponseStateEnum.Created, value: InvoiceStatusResponseStateEnum.Created },
+  { name: InvoiceStatusResponseStateEnum.Sent, value: InvoiceStatusResponseStateEnum.Sent },
+  { name: InvoiceStatusResponseStateEnum.Paid, value: InvoiceStatusResponseStateEnum.Paid },
+  { name: InvoiceStatusResponseStateEnum.Deleted, value: InvoiceStatusResponseStateEnum.Deleted },
+  { name: 'ALL', value: null }
+]);
 
-const viewInvoice = async (id: number) => {
+async function viewInvoice(id: number) {
   let route = router.resolve({ name: 'invoiceInfo', params: { id } });
   window.open(route.href, '_blank');
-};
-
-const props = defineProps({
-  state: {
-    type: String as PropType<InvoiceStatusResponseStateEnum>,
-    required: true,
-  }
-});
-
-onMounted(async () => {
-  await loadInvoices();
-});
-
-async function loadInvoices(skip = 0) {
-  isLoading.value = true;
-  const response = await invoiceStore.fetchInvoices(rows.value, skip, props.state);
-  if (response) {
-    invoices.value = response.records as InvoiceResponse[];
-    totalRecords.value = response._pagination.count || 0;
-  }
-  isLoading.value = false;
 }
 
-async function onPage(event: DataTablePageEvent) {
-  await loadInvoices(event.first);
-}
+const filters = ref({
+  'currentState.state': { value: null, matchMode: 'equals' }
+});
 </script>
 
 <style scoped lang="scss">
-/* Add your custom styles here */
+.truncate {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cell-content {
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  box-sizing: border-box;
+}
+
+
+.skeleton-fixed {
+  height: 1rem;
+  margin: 0;
+  display: block;
+}
 </style>

--- a/apps/dashboard/src/modules/financial/components/invoice/InvoiceTableState.vue
+++ b/apps/dashboard/src/modules/financial/components/invoice/InvoiceTableState.vue
@@ -1,0 +1,76 @@
+<template>
+  <InvoiceTable
+      :invoices="invoices"
+      :totalRecords="totalRecords"
+      :isLoading="isLoading"
+      :rows="rows"
+      @page="onPage"
+      @stateFilterChange="onStateFilterChange"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, type PropType } from "vue";
+import InvoiceTable from "@/modules/financial/components/invoice/InvoiceTable.vue";
+import type { InvoiceResponse } from "@sudosos/sudosos-client";
+import { InvoiceStatusResponseStateEnum } from "@sudosos/sudosos-client/src/api";
+import { useInvoiceStore } from "@/stores/invoice.store";
+
+const invoiceStore = useInvoiceStore();
+
+const totalRecords = ref<number>(0);
+const isLoading = ref<boolean>(true);
+const invoices = ref<InvoiceResponse[]>([]);
+const rows = ref<number>(10);
+const page = ref<number>(0);
+const filterState = ref<InvoiceStatusResponseStateEnum | null>(null);
+
+const props = defineProps({
+  state: {
+    type: String as PropType<InvoiceStatusResponseStateEnum>,
+  },
+  year: {
+    type: Number,
+    required: true,
+  }
+});
+
+onMounted(async () => {
+  await loadInvoices();
+});
+
+async function loadInvoices() {
+  isLoading.value = true;
+
+  // If a year is provided, compute the date range based on the year.
+  // Example: for year 2025, fromDate = "2024-07-01" and tillDate = "2025-07-01"
+  let queryParams: Record<string, any> = { };
+  if (props.year) {
+    queryParams.fromDate = `${props.year - 1}-07-01T00:00:00.000Z`;
+    queryParams.tillDate = `${props.year}-07-01T00:00:00.000Z`;
+  }
+
+  if (filterState.value) {
+    queryParams.state = filterState.value;
+  }
+
+  const response = await invoiceStore.fetchInvoices(rows.value, page.value, queryParams);
+  if (response) {
+    invoices.value = response.records as InvoiceResponse[];
+    totalRecords.value = response._pagination.count || 0;
+  }
+  isLoading.value = false;
+}
+
+async function onPage(event: any) {
+  rows.value = event.rows;
+  page.value = event.first;
+  await loadInvoices();
+}
+
+function onStateFilterChange(e: any) {
+  filterState.value = e.value;
+  console.log(filterState.value);
+  loadInvoices();
+}
+</script>

--- a/apps/dashboard/src/modules/financial/views/invoice/InvoiceOverview.vue
+++ b/apps/dashboard/src/modules/financial/views/invoice/InvoiceOverview.vue
@@ -14,8 +14,8 @@
           />
         </div>
           <TabView class="w-full">
-            <TabPanel v-for="state in states" :key="state" :header="state">
-              <InvoiceTable :state="state" />
+            <TabPanel v-for="year in years" :key="year" :header="year.toString()">
+              <InvoiceTableState :year="year" />
             </TabPanel>
           </TabView>
       </div>
@@ -23,10 +23,9 @@
 </template>
 
 <script setup lang="ts">
-import InvoiceTable from "@/modules/financial/components/invoice/InvoiceTable.vue";
+import InvoiceTableState from "@/modules/financial/components/invoice/InvoiceTableState.vue";
 import TabPanel from "primevue/tabpanel";
 import TabView from "primevue/tabview";
-import { InvoiceStatusResponseStateEnum } from "@sudosos/sudosos-client/src/api";
 import { useI18n } from "vue-i18n";
 import Button from "primevue/button";
 import router from "@/router";
@@ -34,8 +33,11 @@ import InvoiceAccountOverview from "@/modules/financial/views/invoice/InvoiceAcc
 
 const { t } = useI18n();
 
-const states = [ InvoiceStatusResponseStateEnum.Created, InvoiceStatusResponseStateEnum.Sent,
-  InvoiceStatusResponseStateEnum.Paid, InvoiceStatusResponseStateEnum.Deleted ];
+const years = Array.from(
+    { length: Number(new Date().getMonth() > 5) + new Date().getFullYear() - 2022 },
+    (_, i) => new Date().getFullYear() + Number(new Date().getMonth() > 5) - i
+);
+
 
 const navigateToCreateInvoice = () => {
   router.push({ name: 'invoiceCreate' });

--- a/apps/dashboard/src/stores/invoice.store.ts
+++ b/apps/dashboard/src/stores/invoice.store.ts
@@ -58,12 +58,14 @@ export const useInvoiceStore = defineStore('invoice', {
                 return this.invoices[invoice.id];
             });
         },
-        async fetchInvoices(take: number, skip: number, state?: InvoiceStatusResponseStateEnum):
+        async fetchInvoices(take: number, skip: number,
+                    q: { state?: InvoiceStatusResponseStateEnum, fromDate?: string, tillDate?: string }):
           Promise<PaginatedInvoiceResponse> {
+            const { state, fromDate, tillDate } = q;
             // Following line has a bug in the swagger generator
             // @ts-ignore
             return await ApiService.invoices.getAllInvoices(undefined, undefined, state ? state : undefined,
-              undefined, undefined, undefined, take, skip).then((res) => {
+              undefined, fromDate, tillDate, take, skip).then((res) => {
                 const invoices = res.data.records as InvoiceResponse[];
               invoices.forEach((invoice) => {
                     this.invoices[invoice.id] = invoice;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Invoice overview now shows invoices per year instead of state, as people (BACPM) think more in years instead of states.

## Related issues/external references
Closes #517

## Types of changes
- New feature _(non-breaking change which adds functionality)_
