### PR TITLE
fix: footer information for contributions

### DIFF
--- a/apps/dashboard/src/components/footer/FooterContactModal.vue
+++ b/apps/dashboard/src/components/footer/FooterContactModal.vue
@@ -29,12 +29,8 @@
                 https://github.com/GEWIS/sudosos-backend
             </a><br>
             <a class="text-color"
-                href="https://github.com/GEWIS/sudosos-frontend-vue3">
+                href="https://github.com/GEWIS/sudosos-frontend">
                 https://github.com/GEWIS/sudosos-frontend
-            </a><br>
-            <a class="text-color"
-                href="https://github.com/GEWIS/sudosos-pos-vue3">
-                https://github.com/GEWIS/sudosos-pos
             </a><br>
 
         </div>


### PR DESCRIPTION
# Description
Footer still mentioned the old `pos` and `dashboard` repositories, which have been moved to a monorepo.

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_