### PR TITLE
feature: adds full product names up to 3 lines

### DIFF
--- a/apps/point-of-sale/src/components/ProductComponent.vue
+++ b/apps/point-of-sale/src/components/ProductComponent.vue
@@ -5,7 +5,9 @@
            class="product-card-image" :src="image" :alt="product.name" @click="addToCart"/>
       <div v-if="product.featured" class="promo-tag">PROMO</div>
     </div>
-    <p class="product-name text-overflow font-size-md font-semibold m-0 px-2" >{{ product.name }}</p>
+    <div class="product-name-wrapper">
+      <p class="product-name font-size-md font-semibold m-0 px-2" >{{ product.name }}</p>
+    </div>
     <p class="product-price font-size-sm m-0">€{{ productPrice }}</p>
   </div>
 </template>
@@ -103,7 +105,6 @@ const startFlyingAnimation = async () => {
 </script>
 
 <style scoped lang="scss">
-
 .product-card-image {
   width: $product-card-size;
   height: $product-card-size;
@@ -123,11 +124,8 @@ const startFlyingAnimation = async () => {
 
 .product-card {
   padding: 0 0 8px 0;
-  height: fit-content;
   border-radius: $border-radius;
-  overflow: hidden;
   width: var(--product-card-width);
-  text-align: center;
 
   &.pulsing {
     animation: pulse 0.5s infinite;
@@ -150,6 +148,25 @@ const startFlyingAnimation = async () => {
   text-align: center;
   font-size: 1.2em;
   padding: 5px 0;
+}
+
+.product-name-wrapper {
+  height: calc(1.2em * 2.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.product-name {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1;
+  padding-bottom: 0.1em;
 }
 
 .product-price {


### PR DESCRIPTION

# Description
Makes the product names up to 3 lines, then if the product name is still too long it will clamp the remainder.
Solves having unclear product names because the possibly important details were getting overflowed.

Before:
<img width="1281" alt="Screenshot 2025-04-12 at 17 14 12" src="https://github.com/user-attachments/assets/cf859bf3-f2df-428b-af85-1c16187d0cf6" />

After:
<img width="1308" alt="Screenshot 2025-04-12 at 17 15 05" src="https://github.com/user-attachments/assets/8bf4953f-d4e0-4e9f-95da-7accb93f2d9f" />

## Types of changes
- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- Style _(Change that do not affect the functionality of the code)_
