### PR TITLE
Show green menu bar in beta

### DIFF
--- a/apps/dashboard/src/components/TopNavbar.vue
+++ b/apps/dashboard/src/components/TopNavbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="bg-primary flex justify-content-around w-full">
+  <nav class="bg-primary flex justify-content-around w-full" :class="isBeta ? 'bg-green-500' : 'bg-primary'">
     <Menubar class="hidden mb:flex" :model="navItems">
       <template #start>
         <router-link class="align-items-center flex flex-row font-bold no-underline py-1 text-white" to="/">
@@ -84,6 +84,7 @@ import apiService from '@/services/ApiService';
 
 import { useOpenInvoiceAccounts } from '@/mixins/openInvoiceAccountsMixin';
 import { isAllowed } from '@/utils/permissionUtils';
+import { isBetaEnabled } from '@/utils/betaUitl';
 const userStore = useUserStore();
 const authStore = useAuthStore();
 const router = useRouter();
@@ -97,6 +98,8 @@ const handleLogout = () => {
   authStore.logout();
   void router.push('/');
 };
+
+const isBeta = isBetaEnabled();
 
 const { pendingPayouts } = usePendingPayouts();
 const { openInvoiceAccounts } = useOpenInvoiceAccounts();

--- a/apps/dashboard/src/styles/themes/_extensions.scss
+++ b/apps/dashboard/src/styles/themes/_extensions.scss
@@ -29,9 +29,8 @@ body {
   margin: 0;
 }
 
-/* Fix menubar color to GEWIS red */
 .p-menubar {
-  background: variables.$primaryColor;
+  background: inherit;
 }
 
 /* Fix original font */

--- a/apps/dashboard/src/utils/betaUitl.ts
+++ b/apps/dashboard/src/utils/betaUitl.ts
@@ -1,0 +1,4 @@
+export function isBetaEnabled(): boolean {
+  const match = document.cookie.match(/(?:^|;\s*)X-Beta-Enabled=([^;]*)/);
+  return match?.[1] === 'true';
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Show a green menu bar if the beta is enabled, I am aware that dropdown colors  dont work, but its just for a beta indicator.

![image](https://github.com/user-attachments/assets/635751a0-b1fb-4149-84c2-e9948d673182)


## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->- New feature _(non-breaking change which adds functionality)_