### PR TITLE
Add reactive conditional theme switching

### DIFF
--- a/apps/dashboard/src/components/FormCard.vue
+++ b/apps/dashboard/src/components/FormCard.vue
@@ -1,7 +1,7 @@
 <template>
   <CardComponent :header="header">
     <template #topAction>
-      <div v-if="showEdit" class="mx-2">
+      <div v-if="showEdit" class="mx-2 min-w-[200px] flex justify-end">
         <div v-if="!edit">
           <Button icon="pi pi-pencil" :label="t('common.edit')" severity="primary" @click="toggleEdit(true)" />
         </div>

--- a/apps/dashboard/src/components/TopNavbar.vue
+++ b/apps/dashboard/src/components/TopNavbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="flex justify-around w-full" :class="isBeta ? 'bg-green-500' : 'navbar-background'">
+  <nav class="flex justify-around w-full navbar-background">
     <Menubar class="hidden lg:flex" :model="navItems">
       <template #start>
         <router-link class="items-center flex flex-row font-bold no-underline py-1 text-white" to="/">
@@ -72,13 +72,12 @@ import { computed, onBeforeMount, ref, type Ref } from 'vue';
 import { useAuthStore, useUserStore } from '@sudosos/sudosos-frontend-common';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
-import { usePendingPayouts } from '@/mixins/pendingPayoutsMixin';
+import { usePendingPayouts } from '@/composables/pendingPayouts';
 import apiService from '@/services/ApiService';
 
-import { useOpenInvoiceAccounts } from '@/mixins/openInvoiceAccountsMixin';
+import { useOpenInvoiceAccounts } from '@/composables/openInvoiceAccounts';
 import { isAllowed } from '@/utils/permissionUtils';
-import { isBetaEnabled } from '@/utils/betaUtil';
-import { useInactiveDebtors } from '@/mixins/inactiveDebtorsMixin';
+import { useInactiveDebtors } from '@/composables/inactiveDebtors';
 const userStore = useUserStore();
 const authStore = useAuthStore();
 const router = useRouter();
@@ -92,8 +91,6 @@ const handleLogout = () => {
   authStore.logout();
   void router.push('/');
 };
-
-const isBeta = isBetaEnabled();
 
 const { pendingPayouts } = usePendingPayouts();
 const { openInvoiceAccounts } = useOpenInvoiceAccounts();

--- a/apps/dashboard/src/components/TopNavbar.vue
+++ b/apps/dashboard/src/components/TopNavbar.vue
@@ -11,15 +11,13 @@
         <router-link v-if="item.route" v-slot="{ href, navigate }" custom :to="item.route">
           <a v-bind="props.action" class="items-center flex justify-between" :href="href" @click="navigate">
             <span class="p-menuitem-text">{{ item.label }}</span>
-            <span v-if="item.notifications" class="p-badge p-badge-danger">{{ item.notifications }}</span>
+            <Badge v-if="item.notifications" class="ml-2" severity="secondary" :value="item.notifications" />
           </a>
         </router-link>
         <a v-else :href="item.url" :target="item.target" v-bind="props.action">
           <div class="items-center flex justify-between">
             <span class="p-menuitem-text">{{ item.label }}</span>
-            <span v-if="item.notifications" class="ml-2 p-badge p-badge-danger-inverse p-badge-no-gutter">
-              {{ item.notifications }}
-            </span>
+            <Badge v-if="item.notifications" class="ml-2" severity="secondary" :value="item.notifications" />
             <span v-else-if="hasSubmenu" class="ml-2 pi pi-angle-down pi-fw" />
           </div>
         </a>

--- a/apps/dashboard/src/composables/conditionalPreset.ts
+++ b/apps/dashboard/src/composables/conditionalPreset.ts
@@ -1,0 +1,31 @@
+import { usePreset } from '@primeuix/themes';
+import { SudososRed } from '@sudosos/themes';
+import type { ComputedRef, Ref, WatchStopHandle } from 'vue';
+import { watchEffect } from 'vue';
+
+type Preset = typeof SudososRed;
+
+type PresetEntry = {
+  condition: Ref<boolean> | ComputedRef<boolean>;
+  preset: Preset;
+};
+
+export function useConditionalPreset(conditions: PresetEntry[], fallback = SudososRed): WatchStopHandle {
+  let currentPreset: Preset = fallback;
+
+  return watchEffect(() => {
+    let selectedPreset = fallback;
+
+    for (const { condition, preset } of conditions) {
+      if (condition.value) {
+        selectedPreset = preset;
+      }
+    }
+
+    // Only apply if the preset has actually changed
+    if (currentPreset !== selectedPreset) {
+      currentPreset = selectedPreset;
+      usePreset(selectedPreset);
+    }
+  });
+}

--- a/apps/dashboard/src/composables/inactiveDebtors.ts
+++ b/apps/dashboard/src/composables/inactiveDebtors.ts
@@ -1,4 +1,3 @@
-// src/mixins/inactiveDebtorsMixin.ts
 import { computed, watch } from 'vue';
 import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import { UserRole } from '@/utils/rbacUtils';

--- a/apps/dashboard/src/composables/openInvoiceAccounts.ts
+++ b/apps/dashboard/src/composables/openInvoiceAccounts.ts
@@ -1,4 +1,3 @@
-// src/mixins/openInvoiceAccountsMixin.ts
 import { computed, watch } from 'vue';
 import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import { UserRole } from '@/utils/rbacUtils';

--- a/apps/dashboard/src/composables/organMember.ts
+++ b/apps/dashboard/src/composables/organMember.ts
@@ -1,0 +1,11 @@
+import { useAuthStore } from '@sudosos/sudosos-frontend-common';
+import { computed } from 'vue';
+
+export function useOrganMember(organId: number) {
+  const authStore = useAuthStore();
+
+  return computed(() => {
+    const organs = authStore.organs ?? [];
+    return organs.some((organ) => organ?.id === organId);
+  });
+}

--- a/apps/dashboard/src/composables/pendingPayouts.ts
+++ b/apps/dashboard/src/composables/pendingPayouts.ts
@@ -1,4 +1,3 @@
-// src/mixins/pendingPayoutsMixin.ts
 import { computed, watch } from 'vue';
 import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import { usePayoutStore } from '@/stores/payout.store';

--- a/apps/dashboard/src/composables/verifyPayout.ts
+++ b/apps/dashboard/src/composables/verifyPayout.ts
@@ -5,7 +5,7 @@ import type { SellerPayoutResponse } from '@sudosos/sudosos-client';
 import { formatPrice } from '@/utils/formatterUtils';
 import ApiService from '@/services/ApiService';
 
-export const verifyPayoutMixin = {
+export const useVerifyPayout = {
   setup() {
     const verifying = ref<boolean>(false);
     const verifySuccess = ref<boolean | null>(null);

--- a/apps/dashboard/src/main.ts
+++ b/apps/dashboard/src/main.ts
@@ -45,6 +45,7 @@ import Stepper from 'primevue/stepper';
 import Step from 'primevue/step';
 import StepList from 'primevue/steplist';
 import Card from 'primevue/card';
+import Badge from 'primevue/badge';
 
 import { SudososRed } from '@sudosos/themes';
 
@@ -117,6 +118,7 @@ app.component('Stepper', Stepper);
 app.component('StepList', StepList);
 app.component('Step', Step);
 app.component('Card', Card);
+app.component('Badge', Badge);
 
 void beforeLoad().then(() => {
   app.use(router);

--- a/apps/dashboard/src/modules/admin/components/users/AdminUserBalance.vue
+++ b/apps/dashboard/src/modules/admin/components/users/AdminUserBalance.vue
@@ -7,7 +7,7 @@
     :router-link="getRouterLink"
     :router-params="getRouterParams"
   >
-    <div class="flex flex-col justify-center">
+    <div class="flex flex-col justify-center mb-4">
       <div v-if="userBalance === null">
         <Skeleton class="h-4rem mx-1rem my-6 w-10rem" />
       </div>

--- a/apps/dashboard/src/modules/admin/views/AdminSingleUserView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminSingleUserView.vue
@@ -6,7 +6,12 @@
     <div class="flex flex-col gap-5">
       <div class="flex flex-col gap-8 justify-between md:flex-row">
         <AdminUserInfoCard v-if="currentUser" class="flex-grow-1" :user="currentUser" />
-        <AdminUserBalance v-if="currentUser" :user="currentUser" @update-mutations="() => mutations?.refresh()" />
+        <AdminUserBalance
+          v-if="currentUser"
+          class="flex-grow-0 self-start"
+          :user="currentUser"
+          @update-mutations="() => mutations?.refresh()"
+        />
       </div>
       <CardComponent class="w-full" :header="t('components.mutations.user')">
         <MutationsBalance ref="mutations" :get-mutations="getUserMutations" modal paginator />

--- a/apps/dashboard/src/modules/seller/components/seller/SellerPayoutInfo.vue
+++ b/apps/dashboard/src/modules/seller/components/seller/SellerPayoutInfo.vue
@@ -82,7 +82,7 @@ import type { SellerPayoutResponse } from '@sudosos/sudosos-client';
 import InputNumber from 'primevue/inputnumber';
 import { useSellerPayoutStore } from '@/stores/seller-payout.store';
 import { formatDateFromString, formatPrice } from '@/utils/formatterUtils';
-import { verifyPayoutMixin } from '@/mixins/verifyPayoutMixin';
+import { useVerifyPayout } from '@/composables/verifyPayout';
 import { getSellerPayoutPdfSrc } from '@/utils/urlUtils';
 import { handleError } from '@/utils/errorUtils';
 import ApiService from '@/services/ApiService';
@@ -97,7 +97,7 @@ const {
   verifyButtonSeverity,
   verifySuccess,
   verifyAmount,
-} = verifyPayoutMixin.setup();
+} = useVerifyPayout.setup();
 const { t } = useI18n();
 const toast = useToast();
 const sellerPayoutStore = useSellerPayoutStore();

--- a/apps/dashboard/src/modules/seller/components/seller/SellerPayoutsTable.vue
+++ b/apps/dashboard/src/modules/seller/components/seller/SellerPayoutsTable.vue
@@ -96,9 +96,9 @@ import { getSellerPayoutPdfSrc } from '@/utils/urlUtils';
 import SellerPayoutInfo from '@/modules/seller/components/seller/SellerPayoutInfo.vue';
 import { useSellerPayoutStore } from '@/stores/seller-payout.store';
 import { handleError } from '@/utils/errorUtils';
-import { verifyPayoutMixin } from '@/mixins/verifyPayoutMixin';
+import { useVerifyPayout } from '@/composables/verifyPayout';
 
-const { verifyPayout, verifying } = verifyPayoutMixin.setup();
+const { verifyPayout, verifying } = useVerifyPayout.setup();
 const toast = useToast();
 const { t } = useI18n();
 const sellerPayoutStore = useSellerPayoutStore();

--- a/apps/dashboard/src/modules/seller/views/POSInfoView.vue
+++ b/apps/dashboard/src/modules/seller/views/POSInfoView.vue
@@ -3,7 +3,7 @@
     <div class="text-4xl mb-4">{{ posName }}</div>
     <div class="flex flex-col gap-5">
       <div class="align-items-stretch flex flex-col gap-5 justify-between md:flex-row">
-        <POSSettingsCard class="flex-1 h-12" :pos-id="id!" />
+        <POSSettingsCard class="flex-1" :pos-id="id!" />
         <CardComponent class="flex-1" :header="t('modules.seller.singlePos.sales')">
           <div v-if="canLoadTransactions" class="h-22 pb-3 text-5xl text-center">{{ formattedTotalSales }}</div>
           <div v-else>{{ t('common.permissionMessages.transactions') }}</div>

--- a/apps/dashboard/src/utils/beforeLoadUtil.ts
+++ b/apps/dashboard/src/utils/beforeLoadUtil.ts
@@ -1,9 +1,15 @@
 import { clearTokenInStorage, populateStoresFromToken, useAuthStore } from '@sudosos/sudosos-frontend-common';
+import { GrolschGreen, BetaBlue } from '@sudosos/themes';
+import { computed } from 'vue';
 import { useSettingsStore } from '@/stores/settings.store';
 import apiService from '@/services/ApiService';
+import { useConditionalPreset } from '@/composables/conditionalPreset';
+import { useOrganMember } from '@/composables/organMember';
+import { isBetaEnabled } from '@/utils/betaUtil';
 
 export default async function beforeLoad() {
   const settingsStore = useSettingsStore();
+
   try {
     await settingsStore.fetchMaintenanceMode();
     await settingsStore.fetchKeys();
@@ -19,4 +25,9 @@ export default async function beforeLoad() {
     const authStore = useAuthStore();
     authStore.logout();
   });
+
+  useConditionalPreset([
+    { condition: useOrganMember(18214), preset: GrolschGreen },
+    { condition: computed(() => isBetaEnabled()), preset: BetaBlue },
+  ]);
 }

--- a/lib/themes/src/color-themes/beta-blue.ts
+++ b/lib/themes/src/color-themes/beta-blue.ts
@@ -1,0 +1,37 @@
+import { definePreset } from '@primeuix/themes';
+import { SudososPreset } from '../sudosos';
+
+export const BetaBlue = definePreset(SudososPreset, {
+  semantic: {
+    colorScheme: {
+      light: {
+        primary: {
+          color: '#1e3a8a',
+          inverseColor: '#ffffff',
+          hoverColor: '#1e40af',
+          activeColor: '#1e3a8a',
+        },
+      },
+      dark: {
+        primary: {
+          color: '#1e3a8a',
+          inverseColor: '#ffffff',
+          contrastColor: '#ffffff',
+          hoverColor: '#1e40af',
+          activeColor: '#1e3a8a',
+        },
+      },
+    },
+  },
+  components: {
+    menubar: {
+      colorScheme: {
+        dark: {
+          root: {
+            background: '#1e3a8a',
+          },
+        },
+      },
+    },
+  },
+});

--- a/lib/themes/src/index.ts
+++ b/lib/themes/src/index.ts
@@ -1,2 +1,3 @@
 export * from './color-themes/sudosos-red';
 export * from './color-themes/grolsch-green';
+export * from './color-themes/beta-blue';


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Following the primevue v4 update #353 we now have cool and hip preset switching.

Specifically we can register presets using `useConditionalPreset`, which will then be watched and reactively applied.

Use cases, currently implemented:

![image](https://github.com/user-attachments/assets/b467ff84-acf7-40b2-b2f2-5a036f3cfab1)
Normal preset because user is logged out **and not in beta**.

User logs in and is part of a specific organ. This organs theme is then applied (dynamically)
 
![image](https://github.com/user-attachments/assets/7b676b83-5bed-45f5-928b-b6f73c0f7e7a)

User enables beta and receives the `beta blue` theme:

![image](https://github.com/user-attachments/assets/3ef45371-4418-44cd-bb16-337f90ac3b7f)


Note that themes have an "implicit" importance. From top to bottom, so the last "passing" condition will be applied.

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
