### PR TITLE
Add dark mode toggle

### DIFF
--- a/apps/dashboard/src/App.vue
+++ b/apps/dashboard/src/App.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router';
 import Toast from 'primevue/toast';
+import { useDarkMode } from '@/composables/darkMode';
+useDarkMode();
 </script>
 
 <template>

--- a/apps/dashboard/src/components/TopNavbar.vue
+++ b/apps/dashboard/src/components/TopNavbar.vue
@@ -34,7 +34,7 @@
           </a>
         </router-link>
         <a v-else :href="item.url" :target="item.target" v-bind="props.action">
-          <span class="p-menuitem-text">{{ item.label }}</span>
+          <span v-if="item.label" class="p-menuitem-text">{{ item.label }}</span>
           <span v-if="item.icon" :class="item.icon" />
           <span v-if="hasSubmenu" class="ml-2 pi pi-angle-down pi-fw" />
         </a>
@@ -78,10 +78,12 @@ import apiService from '@/services/ApiService';
 import { useOpenInvoiceAccounts } from '@/composables/openInvoiceAccounts';
 import { isAllowed } from '@/utils/permissionUtils';
 import { useInactiveDebtors } from '@/composables/inactiveDebtors';
+import { useDarkMode } from '@/composables/darkMode';
 const userStore = useUserStore();
 const authStore = useAuthStore();
 const router = useRouter();
 const { t, locale } = useI18n();
+const { isDark, toggle } = useDarkMode();
 
 const firstName = computed((): string | undefined => {
   return userStore.getCurrentUser.user ? userStore.getCurrentUser.user.firstName : undefined;
@@ -245,6 +247,11 @@ const profileItems = computed(() => [
         },
       },
     ],
+  },
+  {
+    label: '',
+    command: toggle,
+    icon: isDark.value ? 'pi pi-sun' : 'pi pi-moon',
   },
 ]);
 

--- a/apps/dashboard/src/components/TopNavbar.vue
+++ b/apps/dashboard/src/components/TopNavbar.vue
@@ -34,8 +34,8 @@
           </a>
         </router-link>
         <a v-else :href="item.url" :target="item.target" v-bind="props.action">
-          <span v-if="item.label" class="p-menuitem-text">{{ item.label }}</span>
-          <span v-if="item.icon" :class="item.icon" />
+          <span v-if="item.label" :aria-label="item.aria || item.label" class="p-menuitem-text">{{ item.label }}</span>
+          <span v-if="item.icon" :aria-label="item.aria || item.label || 'icon'" :class="item.icon" />
           <span v-if="hasSubmenu" class="ml-2 pi pi-angle-down pi-fw" />
         </a>
       </template>
@@ -250,6 +250,7 @@ const profileItems = computed(() => [
   },
   {
     label: '',
+    aria: 'toggle dark mode',
     command: toggle,
     icon: isDark.value ? 'pi pi-sun' : 'pi pi-moon',
   },

--- a/apps/dashboard/src/composables/darkMode.ts
+++ b/apps/dashboard/src/composables/darkMode.ts
@@ -1,0 +1,31 @@
+import { ref, onMounted } from 'vue';
+
+const DARK_MODE_KEY = 'dark-mode';
+
+/**
+ * Composable for managing dark mode
+ * @returns {Object} Object containing the isDark, toggle, enable and disable functions
+ */
+export function useDarkMode() {
+  const isDark = ref(false);
+
+  const apply = (value: boolean) => {
+    isDark.value = value;
+    const html = document.documentElement;
+    html.classList.toggle('dark-mode', value);
+    localStorage.setItem(DARK_MODE_KEY, value ? 'true' : 'false');
+  };
+
+  const toggle = () => apply(!isDark.value);
+
+  onMounted(() => {
+    apply(localStorage.getItem(DARK_MODE_KEY) === 'true');
+  });
+
+  return {
+    isDark,
+    toggle,
+    enable: () => apply(true),
+    disable: () => apply(false),
+  };
+}

--- a/apps/dashboard/src/composables/darkMode.ts
+++ b/apps/dashboard/src/composables/darkMode.ts
@@ -16,10 +16,21 @@ export function useDarkMode() {
     localStorage.setItem(DARK_MODE_KEY, value ? 'true' : 'false');
   };
 
+  const applyFromSystem = () => {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    isDark.value = prefersDark;
+    document.documentElement.classList.toggle('dark-mode', prefersDark);
+  };
+
   const toggle = () => apply(!isDark.value);
 
   onMounted(() => {
-    apply(localStorage.getItem(DARK_MODE_KEY) === 'true');
+    const stored = localStorage.getItem(DARK_MODE_KEY);
+    if (stored === null) {
+      applyFromSystem();
+    } else {
+      apply(stored === 'true');
+    }
   });
 
   return {

--- a/apps/dashboard/src/modules/user/components/UserInfo.vue
+++ b/apps/dashboard/src/modules/user/components/UserInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <CardComponent :header="t('components.general.quickOverview.header')">
     <p class="text-gray-700">{{ t('components.general.quickOverview.message') }}</p>
-    <h1 class="text-center text-2xl font-bold text-gray-800 my-4">
+    <h1 class="text-center text-2xl font-bold my-4">
       {{ isGewisUser(props.user) ? props.user.gewisId : `E${props.user.id}` }} <br />
       {{ props.user.firstName }} {{ props.user.lastName }}
     </h1>

--- a/apps/dashboard/src/modules/user/views/UserProfileView.vue
+++ b/apps/dashboard/src/modules/user/views/UserProfileView.vue
@@ -3,9 +3,8 @@
     <div class="text-4xl mb-4">{{ t('modules.user.profile.title') }}</div>
     <div class="flex flex-col">
       <div class="flex flex-col justify-between md:flex-row">
-        <!-- Adjusted width -->
         <UserSettingsComponent class="flex-grow-1" :user="current.user as UserResponse" />
-        <UserInfo :user="gewisUser || (current.user as GewisUserResponse)" />
+        <UserInfo class="self-start shrink-0" :user="gewisUser || (current.user as GewisUserResponse)" />
       </div>
     </div>
   </PageContainer>

--- a/lib/themes/src/color-themes/beta-blue.ts
+++ b/lib/themes/src/color-themes/beta-blue.ts
@@ -14,10 +14,10 @@ export const BetaBlue = definePreset(SudososPreset, {
       },
       dark: {
         primary: {
-          color: '#1e3a8a',
+          color: '#2a42bd',
           inverseColor: '#ffffff',
           contrastColor: '#ffffff',
-          hoverColor: '#1e40af',
+          hoverColor: '#1a3796',
           activeColor: '#1e3a8a',
         },
       },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Wow! Adds a composable for dealing with dark mode. Preference is stored in local storage under `dark-mode`.

![image](https://github.com/user-attachments/assets/3bb15f35-7c7a-426e-aa05-9f3dc8f2124a)

![image](https://github.com/user-attachments/assets/5798e362-dced-434e-8be7-ef64879650bc)

This might  require some style changes as we go. But anyhow.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

- New feature _(non-breaking change which adds functionality)_
