### PR TITLE
fix: improve styling of payouts by moving validation to schema

### DIFF
--- a/apps/dashboard/src/components/InputSelectSpan.vue
+++ b/apps/dashboard/src/components/InputSelectSpan.vue
@@ -23,8 +23,8 @@
 </template>
 
 <script setup lang="ts" generic="T">
-import ErrorSpan from '@/components/ErrorSpan.vue';
 import { useAttrs } from 'vue';
+import ErrorSpan from '@/components/ErrorSpan.vue';
 
 defineOptions({ inheritAttrs: false });
 const attrs = useAttrs();

--- a/apps/dashboard/src/components/InputUserSpan.vue
+++ b/apps/dashboard/src/components/InputUserSpan.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <span :class="['flex flex-wrap justify-between', column ? 'flex-col gap-1' : 'flex-row items-center gap-3']">
+    <span :class="['flex justify-between', column ? 'flex-col gap-1' : 'flex-row items-center gap-3']">
       <span class="my-0">{{ label }}</span>
       <FindUser
         v-model:user="internalValue"
@@ -42,6 +42,7 @@ const props = withDefaults(
     value: undefined,
     errors: undefined,
     placeholder: '',
+    column: false,
     type: undefined,
     showPositive: true,
   },

--- a/apps/dashboard/src/modules/financial/components/payout/PayoutTable.vue
+++ b/apps/dashboard/src/modules/financial/components/payout/PayoutTable.vue
@@ -62,7 +62,7 @@
     <Dialog
       ref="dialog"
       v-model:visible="showModal"
-      class="flex w-1/3"
+      class="flex max-w-[40rem] w-full"
       :draggable="false"
       :header="t('modules.financial.payout.details', { payoutId })"
       modal


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

So the latest changes to the InputSpan gave it a flex-grow, which makes sense as you would it to fill the space. However this leaves it to the parent component to actually style these inputs. Whilst fixing this I also fixed some old code as a good boyscout.

Old:
![image](https://github.com/user-attachments/assets/15656abc-8924-43e6-a0b8-a4ec7978b875)

New:
![image](https://github.com/user-attachments/assets/8e022bdd-6ded-4166-b10b-3fd1a48ccc07)



## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_