### PR TITLE
fix: styling of mutations table on phones

### DIFF
--- a/apps/dashboard/src/components/mutations/MutationsBalance.vue
+++ b/apps/dashboard/src/components/mutations/MutationsBalance.vue
@@ -18,7 +18,7 @@
             dateStyle: 'full',
           })
         }}</span>
-        <span class="sm:hidden"
+        <span class="sm:hidden whitespace-nowrap"
           >{{
             mutation.data.moment.toLocaleDateString('nl-NL', {
               dateStyle: 'short',
@@ -28,7 +28,7 @@
       </template>
     </Column>
 
-    <Column field="createdBy" :header="t('components.mutations.createdBy')">
+    <Column field="createdBy" :header="t(`components.mutations.${isMd ? 'createdBy' : 'By'}`)">
       <template v-if="isLoading" #body>
         <Skeleton class="h-1rem my-1 surface-300 w-6" />
       </template>
@@ -99,10 +99,11 @@ import { formatPrice } from '@/utils/formatterUtils';
 import { type FinancialMutation, FinancialMutationType, parseFinancialMutations } from '@/utils/mutationUtils';
 import ModalMutation from '@/components/mutations/mutationmodal/ModalMutation.vue';
 import { isIncreasingTransfer, isFine } from '@/utils/mutationUtils';
+import { useSizeBreakpoints } from '@/composables/sizeBreakpoints';
 
 const { t, locale } = useI18n();
-
 const userStore = useUserStore();
+const { isMd } = useSizeBreakpoints();
 
 const props = defineProps<{
   getMutations: (take: number, skip: number) => Promise<PaginatedFinancialMutationResponse | undefined>;

--- a/apps/dashboard/src/composables/sizeBreakpoints.ts
+++ b/apps/dashboard/src/composables/sizeBreakpoints.ts
@@ -1,0 +1,28 @@
+import { ref, onMounted, onUnmounted, computed } from 'vue';
+
+const breakpoints = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536,
+};
+
+export function useSizeBreakpoints() {
+  const width = ref(window.innerWidth);
+
+  function onResize() {
+    width.value = window.innerWidth;
+  }
+
+  onMounted(() => window.addEventListener('resize', onResize));
+  onUnmounted(() => window.removeEventListener('resize', onResize));
+
+  const isSm = computed(() => width.value >= breakpoints.sm);
+  const isMd = computed(() => width.value >= breakpoints.md);
+  const isLg = computed(() => width.value >= breakpoints.lg);
+  const isXl = computed(() => width.value >= breakpoints.xl);
+  const is2xl = computed(() => width.value >= breakpoints['2xl']);
+
+  return { width, isSm, isMd, isLg, isXl, is2xl };
+}

--- a/apps/dashboard/src/locales/en/components/mutations.json
+++ b/apps/dashboard/src/locales/en/components/mutations.json
@@ -7,6 +7,7 @@
       "when": "When",
       "created": "Created transactions",
       "createdBy": "Created by",
+      "By": "By",
       "createdFor": "Created for",
       "amount": "Amount",
       "pos": "Point of sale",

--- a/apps/dashboard/src/locales/nl/components/mutations.json
+++ b/apps/dashboard/src/locales/nl/components/mutations.json
@@ -7,6 +7,7 @@
       "when": "Wanneer",
       "created": "Aangemaakte transacties",
       "createdBy": "Aangemaakt door",
+      "By": "Door",
       "createdFor": "Aangemaakt voor",
       "amount": "Bedrag",
       "pos": "Verkooppunt",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Smal QOL for phones. Added a composable to use tailwind CSS breakpoints as javascript vars.

Old:
![WhatsApp Image 2025-06-25 at 23 40 03_9c1d1185](https://github.com/user-attachments/assets/02291dec-adee-4657-afc4-eab620a40012)

New:
![WhatsApp Image 2025-06-25 at 23 40 03_40c7dc71](https://github.com/user-attachments/assets/8f20d908-af99-4e19-b505-fd826a2fe2df)


## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
