### PR TITLE
feat(dashboard): show user link based on permissions

### DIFF
--- a/apps/dashboard/src/components/UserLink.vue
+++ b/apps/dashboard/src/components/UserLink.vue
@@ -1,24 +1,36 @@
 <template>
-  <a class="cursor-pointer hover:opacity-80 text-primary" @click="goToUser">
-    {{ user.firstName }} {{ user.lastName }}
+  <a v-if="allowed" class="cursor-pointer hover:opacity-80 text-primary" @click="goToUser">
+    {{ name }}
   </a>
+  <span v-else>{{ name }}</span>
 </template>
 
 <script setup lang="ts">
 import type { BaseUserResponse } from '@sudosos/sudosos-client';
-import type { PropType } from 'vue';
+import { computed } from 'vue';
 import router from '@/router';
+import { getRelation, isAllowed } from '@/utils/permissionUtils';
 
-const props = defineProps({
-  user: {
-    type: Object as PropType<BaseUserResponse>,
-    required: true,
-  },
-  newTab: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
+/**
+ * Props for UserLink component.
+ * @property user - The user to link to.
+ * @property [newTab=false] - Open in new tab if true.
+ */
+interface UserLinkProps {
+  user: BaseUserResponse;
+  newTab?: boolean;
+}
+
+/**
+ * Renders a link to a user's profile page.
+ */
+const props = defineProps<UserLinkProps>();
+
+// If the user cannot get the balance, there is not much sensible to see at the profile page anyway.
+const allowed = isAllowed('get', [getRelation(props.user.id)], 'Balance', ['any']);
+
+const name = computed(() => {
+  return `${props.user.firstName} ${props.user.lastName}`.trim();
 });
 
 const goToUser = () => {

--- a/apps/dashboard/src/components/mutations/mutationmodal/ModalDetailTransaction.vue
+++ b/apps/dashboard/src/components/mutations/mutationmodal/ModalDetailTransaction.vue
@@ -12,19 +12,16 @@
       {{ t('components.mutations.userBoughtAt', { pos: transactionInfo.pointOfSale.name }) }}
     </span>
     <span v-if="transactionInfo.from.id != userStore.current.user!!.id">
+      <UserLink :new-tab="true" :user="transactionInfo.from" />
       {{
-        t('components.mutations.otherBoughtAt', {
-          user: `${transactionInfo.from.firstName} ${transactionInfo.from.lastName}`,
+        t('components.mutations.otherBoughtAt.suffix', {
           pos: transactionInfo.pointOfSale.name,
         })
       }}
     </span>
     <span v-if="transactionInfo.createdBy && transactionInfo.createdBy.id != transactionInfo.from.id">
-      {{
-        t('components.mutations.putInBy', {
-          createdBy: `${transactionInfo.createdBy.firstName} ${transactionInfo.createdBy.lastName}`,
-        })
-      }}
+      {{ t('components.mutations.putInBy.prefix') }}
+      <UserLink :new-tab="true" :user="transactionInfo.createdBy" />
     </span>
 
     <br />
@@ -74,6 +71,7 @@ import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
 import { sendEmail } from '@/utils/mailUtil';
 import { formatPrice } from '@/utils/formatterUtils';
+import UserLink from '@/components/UserLink.vue';
 
 const { t } = useI18n();
 

--- a/apps/dashboard/src/locales/en/components/mutations.json
+++ b/apps/dashboard/src/locales/en/components/mutations.json
@@ -29,8 +29,12 @@
         "unknown": "Unknown transaction"
       },
       "userBoughtAt": "You bought at {pos}",
-      "otherBoughtAt": "{user} bought at {pos}",
-      "putInBy": "Transaction put in by {createdBy}"
+      "otherBoughtAt": {
+        "suffix": " bought at {pos}"
+      },
+      "putInBy": {
+        "prefix": "Transaction put in by "
+      }
     }
   }
 }

--- a/apps/dashboard/src/locales/nl/components/mutations.json
+++ b/apps/dashboard/src/locales/nl/components/mutations.json
@@ -29,8 +29,12 @@
         "unknown": "Onbekende transactie"
       },
       "userBoughtAt": "Je hebt gekocht bij {pos}",
-      "otherBoughtAt": "{user} heeft gekocht bij {pos}",
-      "putInBy": "Transactie ingevoerd door {createdBy}"
+      "otherBoughtAt": {
+        "suffix": " heeft gekocht bij {pos}"
+      },
+      "putInBy": {
+        "prefix": "Transactie geplaatst door "
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
`UserLink` now uses the `get Balance` permission to check if navigation to a user would be sensible.

This improves navigability of the dashboard

Current:
![image](https://github.com/user-attachments/assets/838b7a35-9d68-43f7-ac71-64b76c78c3dc)


New (with permissions):
![image](https://github.com/user-attachments/assets/c5f8b07b-df81-405e-81b3-8c315e714f0a)

New (without permissions, nothing changed):
![image](https://github.com/user-attachments/assets/53b67785-3418-4276-a520-482a5e165bd3)


## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_