### PR TITLE
fix(dashboard): userlink not showing `you`

### DIFF
--- a/apps/dashboard/src/components/UserLink.vue
+++ b/apps/dashboard/src/components/UserLink.vue
@@ -8,8 +8,13 @@
 <script setup lang="ts">
 import type { BaseUserResponse } from '@sudosos/sudosos-client';
 import { computed } from 'vue';
+import { useAuthStore } from '@sudosos/sudosos-frontend-common';
+import { useI18n } from 'vue-i18n';
 import router from '@/router';
 import { getRelation, isAllowed } from '@/utils/permissionUtils';
+
+const { t } = useI18n();
+const authStore = useAuthStore();
 
 /**
  * Props for UserLink component.
@@ -29,7 +34,10 @@ const props = defineProps<UserLinkProps>();
 // If the user cannot get the balance, there is not much sensible to see at the profile page anyway.
 const allowed = isAllowed('get', [getRelation(props.user.id)], 'Balance', ['any']);
 
+const u = authStore.getUser;
+
 const name = computed(() => {
+  if (u?.id === props.user.id) return t('components.mutations.you');
   return `${props.user.firstName} ${props.user.lastName}`.trim();
 });
 

--- a/apps/dashboard/src/components/mutations/mutationmodal/ModalDetailTransaction.vue
+++ b/apps/dashboard/src/components/mutations/mutationmodal/ModalDetailTransaction.vue
@@ -8,10 +8,7 @@
         })
       }}
     </span>
-    <span v-if="transactionInfo.from.id == userStore.current.user!!.id">
-      {{ t('components.mutations.userBoughtAt', { pos: transactionInfo.pointOfSale.name }) }}
-    </span>
-    <span v-if="transactionInfo.from.id != userStore.current.user!!.id">
+    <span>
       <UserLink :new-tab="true" :user="transactionInfo.from" />
       {{
         t('components.mutations.otherBoughtAt.suffix', {
@@ -65,7 +62,6 @@
 <script setup lang="ts">
 import type { SubTransactionRowResponse } from '@sudosos/sudosos-client/src/api';
 import type { TransactionResponse } from '@sudosos/sudosos-client';
-import { useUserStore } from '@sudosos/sudosos-frontend-common';
 import { useI18n } from 'vue-i18n';
 import DataTable from 'primevue/datatable';
 import Column from 'primevue/column';
@@ -74,8 +70,6 @@ import { formatPrice } from '@/utils/formatterUtils';
 import UserLink from '@/components/UserLink.vue';
 
 const { t } = useI18n();
-
-const userStore = useUserStore();
 
 defineProps({
   transactionInfo: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Userlink now formats the name as `You` in case auth matches.

![image](https://github.com/user-attachments/assets/14d88d45-6859-46f3-8d0d-1699a74c95ce)

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_