### PR TITLE
Add maintainer view and admin actions

### DIFF
--- a/apps/dashboard/src/components/ConfirmButton.vue
+++ b/apps/dashboard/src/components/ConfirmButton.vue
@@ -5,13 +5,17 @@
     :label="labelText"
     :severity="severity"
     :type="type"
+    v-bind="attrs"
     @blur="reset"
     @click="handleClick"
   />
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
+import { ref, computed, useAttrs } from 'vue';
+
+defineOptions({ inheritAttrs: false });
+const attrs = useAttrs();
 
 const props = defineProps<{
   disabled?: boolean;

--- a/apps/dashboard/src/locales/en/common/common.json
+++ b/apps/dashboard/src/locales/en/common/common.json
@@ -158,7 +158,8 @@
       "debtors": "Debtors",
       "invoiceAccounts": "Invoice Account Overview",
       "fines": "Fines",
-      "writeOffs": "Write-Offs"
+      "writeOffs": "Write-Offs",
+      "maintainer": "Maintainer"
     },
     "validation": {
       "number": {

--- a/apps/dashboard/src/locales/en/modules/admin.json
+++ b/apps/dashboard/src/locales/en/modules/admin.json
@@ -67,6 +67,23 @@
           "ofAge": "User is of age",
           "canGoIntoDebt": "User can go into debt"
         }
+      },
+      "actions": {
+        "title": "Admin actions"
+      },
+      "maintenance": {
+        "maintenanceMode": "Maintenance mode",
+        "confirm": {
+          "initial": "Maintenance is {enabled}",
+          "confirm": "Turn {enabled}?",
+          "on": "on",
+          "off": "off",
+          "enabled": "enabled",
+          "disabled": "disabled"
+        }
+      },
+      "websocket": {
+        "title": "Websocket logs"
       }
     }
   }

--- a/apps/dashboard/src/locales/nl/common/common.json
+++ b/apps/dashboard/src/locales/nl/common/common.json
@@ -157,7 +157,8 @@
       "debtors": "Schuldigen",
       "invoiceAccounts": "Facturen Account Overzicht",
       "fines": "Boetes",
-      "writeOffs": "Afschrijvingen"
+      "writeOffs": "Afschrijvingen",
+      "maintainer": "Maintainer"
     },
     "validation": {
       "number": {

--- a/apps/dashboard/src/locales/nl/modules/admin.json
+++ b/apps/dashboard/src/locales/nl/modules/admin.json
@@ -67,6 +67,23 @@
           "ofAge": "Gebruiker is meerderjarig",
           "canGoIntoDebt": "Gebruiker kan schulden maken"
         }
+      },
+      "actions": {
+        "title": "Admin acties"
+      },
+      "maintenance": {
+        "maintenanceMode": "Onderhoud modus",
+        "confirm": {
+          "initial": "Onderhoud is {enabled}",
+          "confirm": "Schakel {enabled}?",
+          "on": "aan",
+          "off": "uit",
+          "enabled": "ingeschakeld",
+          "disabled": "uitgeschakeld"
+        }
+      },
+      "websocket": {
+        "title": "Websocket logs"
       }
     }
   }

--- a/apps/dashboard/src/main.ts
+++ b/apps/dashboard/src/main.ts
@@ -46,6 +46,7 @@ import Step from 'primevue/step';
 import StepList from 'primevue/steplist';
 import Card from 'primevue/card';
 import Badge from 'primevue/badge';
+import VirtualScroller from 'primevue/virtualscroller';
 
 import { SudososRed } from '@sudosos/themes';
 
@@ -123,6 +124,7 @@ app.component('StepList', StepList);
 app.component('Step', Step);
 app.component('Card', Card);
 app.component('Badge', Badge);
+app.component('VirtualScroller', VirtualScroller);
 
 void beforeLoad().then(() => {
   app.use(router);

--- a/apps/dashboard/src/modules/admin/components/MaintenanceToggle.vue
+++ b/apps/dashboard/src/modules/admin/components/MaintenanceToggle.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="flex flex-row gap-2 items-center justify-between">
+    <span> {{ t('modules.admin.maintenance.maintenanceMode') }} </span>
+    <ConfirmButton
+      class="min-w-[220px]"
+      :confirm-label="
+        t('modules.admin.maintenance.confirm.confirm', {
+          enabled: isMaintenance
+            ? t('modules.admin.maintenance.confirm.off')
+            : t('modules.admin.maintenance.confirm.on'),
+        })
+      "
+      icon="pi pi-exclamation-triangle"
+      :initial-label="
+        t('modules.admin.maintenance.confirm.initial', {
+          enabled: isMaintenance
+            ? t('modules.admin.maintenance.confirm.enabled')
+            : t('modules.admin.maintenance.confirm.disabled'),
+        })
+      "
+      type="submit"
+      @confirm="toggleMaintenance"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { useIsMaintenance } from '@/composables/isMaintenance';
+import ConfirmButton from '@/components/ConfirmButton.vue';
+import apiService from '@/services/ApiService';
+
+const { isMaintenance } = useIsMaintenance();
+const { t } = useI18n();
+
+const toggleMaintenance = async () => {
+  await apiService.serverSettings.setMaintenanceMode({
+    enabled: !isMaintenance.value,
+  });
+};
+</script>
+
+<style scoped lang="scss"></style>

--- a/apps/dashboard/src/modules/admin/components/WebsocketLogs.vue
+++ b/apps/dashboard/src/modules/admin/components/WebsocketLogs.vue
@@ -1,0 +1,38 @@
+<template>
+  <VirtualScroller
+    :key="logs.length"
+    class="font-mono rounded-lg p-2 overflow-y-auto"
+    :item-size="28"
+    :items="logs"
+    style="height: 340px; background: var(--p-primary-color); color: var(--p-primary-inverse-color)"
+  >
+    <template #item="{ item }">
+      <div
+        class="log-line whitespace-pre-wrap px-2 py-1 transition-colors"
+        style="border-color: var(--p-primary-inverse-color)"
+      >
+        <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
+        [{{ dateToTimeString(item.time) }}] {{ item.message }}
+      </div>
+    </template>
+  </VirtualScroller>
+</template>
+
+<script setup lang="ts">
+import { useWebSocketStore } from '@sudosos/sudosos-frontend-common';
+import { storeToRefs } from 'pinia';
+import { dateToTimeString } from 'sudosos-dashboard/src/utils/formatterUtils';
+
+const webSocketStore = useWebSocketStore();
+const { logs } = storeToRefs(webSocketStore);
+</script>
+
+<style scoped lang="scss">
+.log-line {
+  cursor: pointer;
+}
+
+.log-line:hover {
+  background: linear-gradient(rgba(0, 0, 0, 0.21), rgba(0, 0, 0, 0.21)), var(--p-primary-color);
+}
+</style>

--- a/apps/dashboard/src/modules/admin/navbar.ts
+++ b/apps/dashboard/src/modules/admin/navbar.ts
@@ -23,6 +23,11 @@ export function useAdminNav() {
           },
         ].filter((item) => item.visible),
       },
+      {
+        label: t('common.navigation.maintainer'),
+        visible: isAllowed('update', ['all'], 'Maintenance', ['*']),
+        route: '/maintainer',
+      },
     ].filter((item) => item.visible),
   );
 }

--- a/apps/dashboard/src/modules/admin/routes.ts
+++ b/apps/dashboard/src/modules/admin/routes.ts
@@ -3,6 +3,7 @@ import DashboardLayout from '@/layout/DashboardLayout.vue';
 import AdminUserOverView from '@/modules/admin/views/AdminUserOverView.vue';
 import AdminBannersView from '@/modules/admin/views/AdminBannersView.vue';
 import AdminSingleUserView from '@/modules/admin/views/AdminSingleUserView.vue';
+import AdminMaintainerView from '@/modules/admin/views/AdminMaintainerView.vue';
 import { isAllowed } from '@/utils/permissionUtils';
 
 export function adminRoutes(): RouteRecordRaw[] {
@@ -39,6 +40,15 @@ export function adminRoutes(): RouteRecordRaw[] {
           meta: {
             requiresAuth: true,
             isAllowed: () => isAllowed('get', ['all'], 'User', ['any']),
+          },
+        },
+        {
+          path: '/maintainer',
+          component: AdminMaintainerView,
+          name: 'maintainer',
+          meta: {
+            requiresAuth: true,
+            isAllowed: () => isAllowed('update', ['all'], 'Maintenance', ['*']),
           },
         },
       ],

--- a/apps/dashboard/src/modules/admin/views/AdminMaintainerView.vue
+++ b/apps/dashboard/src/modules/admin/views/AdminMaintainerView.vue
@@ -1,0 +1,24 @@
+<template>
+  <PageContainer>
+    <div class="flex flex-col gap-10 justify-between flex-grow">
+      <CardComponent class="max-w-[30rem]" :header="t('modules.admin.actions.title')">
+        <MaintenanceToggle />
+      </CardComponent>
+      <CardComponent class="max-w-[30rem]" :header="t('modules.admin.websocket.title')">
+        <WebsocketLogs />
+      </CardComponent>
+    </div>
+  </PageContainer>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import PageContainer from '@/layout/PageContainer.vue';
+import CardComponent from '@/components/CardComponent.vue';
+import MaintenanceToggle from '@/modules/admin/components/MaintenanceToggle.vue';
+import WebsocketLogs from '@/modules/admin/components/WebsocketLogs.vue';
+
+const { t } = useI18n();
+</script>
+
+<style scoped lang="scss"></style>

--- a/apps/dashboard/src/utils/formatterUtils.ts
+++ b/apps/dashboard/src/utils/formatterUtils.ts
@@ -25,6 +25,11 @@ function parseTime(value: number): string {
   return value.toString().padStart(2, '0');
 }
 
+export function dateToTimeString(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
 export function formatPrice(value: Dinero, isNegative?: boolean): string {
   if (isNegative) {
     return ((value.amount / 100) * -1).toLocaleString('nl-NL', { style: 'currency', currency: 'EUR' });

--- a/lib/common/src/services/ApiService.ts
+++ b/lib/common/src/services/ApiService.ts
@@ -21,6 +21,7 @@ import {
   DebtorsApi,
   SellerPayoutsApi,
   WriteoffsApi,
+  ServerSettingsApi,
 } from '@sudosos/sudosos-client';
 import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { getTokenFromStorage, updateTokenIfNecessary } from '../helpers/TokenHelper';
@@ -79,6 +80,8 @@ export class ApiService {
 
   private readonly _writeOffsApi: WriteoffsApi;
 
+  private readonly _serverSettingsApi: ServerSettingsApi;
+
   constructor(basePath: string) {
     const withKeyConfiguration = new Configuration({
       accessToken: () => getTokenFromStorage().token,
@@ -106,6 +109,7 @@ export class ApiService {
     this._rbacApi = new RbacApi(withKeyConfiguration, basePath, axiosInstance);
     this._sellerPayoutsApi = new SellerPayoutsApi(withKeyConfiguration, basePath, axiosInstance);
     this._writeOffsApi = new WriteoffsApi(withKeyConfiguration, basePath, axiosInstance);
+    this._serverSettingsApi = new ServerSettingsApi(withKeyConfiguration, basePath, axiosInstance);
   }
 
   get authenticate(): AuthenticateApi {
@@ -194,5 +198,9 @@ export class ApiService {
 
   get writeOffs(): WriteoffsApi {
     return this._writeOffsApi;
+  }
+
+  get serverSettings(): ServerSettingsApi {
+    return this._serverSettingsApi;
   }
 }

--- a/lib/common/src/services/webSocketService.ts
+++ b/lib/common/src/services/webSocketService.ts
@@ -4,10 +4,20 @@ import { useWebSocketStore } from '../stores/websocket.store';
 export const setupWebSocket = () => {
   const socket = io({
     path: '/ws/socket.io',
-    transports: ['websocket'], // optional: skip polling fallback
+    transports: ['websocket'],
   });
 
   const websocketStore = useWebSocketStore();
+  const addToLogs = (event: string, args: unknown[]) => {
+    const logTime = new Date();
+    const logMsg = `[${event}] ${args.map((a) => JSON.stringify(a)).join(' ')}`;
+    websocketStore.addLog({ time: logTime, message: logMsg });
+  };
+
+  socket.onAny((event, ...args) => {
+    addToLogs(event, args);
+  });
+
   socket.emit('subscribe', 'system');
 
   socket.on('connect', () => {

--- a/lib/common/src/stores/websocket.store.ts
+++ b/lib/common/src/stores/websocket.store.ts
@@ -1,11 +1,14 @@
 import { defineStore } from 'pinia';
 
+type LogEntry = { time: Date; message: string };
+
 export const useWebSocketStore = defineStore('websocket', {
   state: () => ({
     connected: false,
     messages: [] as string[],
     maintenanceMode: false,
     disconnected: false,
+    logs: [] as LogEntry[],
   }),
   actions: {
     setConnected(status: boolean) {
@@ -17,6 +20,9 @@ export const useWebSocketStore = defineStore('websocket', {
     },
     setMaintenanceMode(enabled: boolean) {
       this.maintenanceMode = enabled;
+    },
+    addLog(log: LogEntry) {
+      this.logs.push(log);
     },
   },
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Extends the maintenance mode of the dashboard with being able to actually toggle it.

I put this under admin / maintainer actions. Also added the was, for mostly the reason that a page with a singular button looks sad.

![image](https://github.com/user-attachments/assets/34d31054-11d8-49d5-9f8f-97f996c6e947)


## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_