### PR TITLE
feat: delete NFC in POS

### DIFF
--- a/apps/point-of-sale/src/components/ScannersUpdateComponent.vue
+++ b/apps/point-of-sale/src/components/ScannersUpdateComponent.vue
@@ -25,6 +25,9 @@
       />
       <b style="font-weight: bold !important">Scan your NFC card now!</b><br />
       <b>Note: Banking cards, ID cards and phones will not work</b><br />
+      <button class="active rounded-md c-btn font-medium px-2 py-1 mt-1 text-base" @click="deleteNfc">
+        Remove linked NFC
+      </button>
     </div>
   </Dialog>
 </template>
@@ -41,6 +44,10 @@ const nfcModal: Ref<{ mask: HTMLElement; close: () => void } | null> = ref(null)
 const props = defineProps({
   handleNfcUpdate: {
     type: Function as PropType<(nfcCode: string) => Promise<void>>,
+    required: true,
+  },
+  handleNfcDelete: {
+    type: Function as PropType<() => Promise<void>>,
     required: true,
   },
 });
@@ -94,6 +101,31 @@ const onInput = (event: KeyboardEvent): void => {
     captures.push(event);
   }
 };
+
+const deleteNfc = async () => {
+  await props.handleNfcDelete()
+    .then(() => {
+      nfcModalVisible.value = false;
+
+      toast.add({
+        severity: 'success',
+        summary: 'NFC code removed!',
+        detail: 'The linked NFC code has  been removed.',
+        life: 5000
+      });
+    })
+    .catch((err) => {
+      nfcModalVisible.value = false;
+
+      console.error(err);
+      toast.add({
+        severity: 'error',
+        summary: 'No NFC code added.',
+        detail: 'There is no NFC code linked to your account.',
+        life: 5000
+      });
+    });
+}
 </script>
 
 <style scoped lang="scss">
@@ -105,6 +137,7 @@ const onInput = (event: KeyboardEvent): void => {
 .dialog-close {
   color: white !important;
 }
+
 .nfc-icon {
   height: 100px;
   position: fixed;

--- a/apps/point-of-sale/src/components/ScannersUpdateComponent.vue
+++ b/apps/point-of-sale/src/components/ScannersUpdateComponent.vue
@@ -5,7 +5,7 @@
   <Dialog
     ref="nfcModal"
     v-model:visible="nfcModalVisible"
-    header="Link NFC"
+    header="Manage NFC"
     modal
     :pt="{
       header: () => ({ class: ['dialog-header'] }),
@@ -103,15 +103,16 @@ const onInput = (event: KeyboardEvent): void => {
 };
 
 const deleteNfc = async () => {
-  await props.handleNfcDelete()
+  await props
+    .handleNfcDelete()
     .then(() => {
       nfcModalVisible.value = false;
 
       toast.add({
         severity: 'success',
         summary: 'NFC code removed!',
-        detail: 'The linked NFC code has  been removed.',
-        life: 5000
+        detail: 'The linked NFC code has been removed.',
+        life: 5000,
       });
     })
     .catch((err) => {
@@ -120,12 +121,12 @@ const deleteNfc = async () => {
       console.error(err);
       toast.add({
         severity: 'error',
-        summary: 'No NFC code added.',
+        summary: 'No linked NFC code.',
         detail: 'There is no NFC code linked to your account.',
-        life: 5000
+        life: 5000,
       });
     });
-}
+};
 </script>
 
 <style scoped lang="scss">

--- a/apps/point-of-sale/src/components/ScannersUpdateComponent.vue
+++ b/apps/point-of-sale/src/components/ScannersUpdateComponent.vue
@@ -106,8 +106,6 @@ const deleteNfc = async () => {
   await props
     .handleNfcDelete()
     .then(() => {
-      nfcModalVisible.value = false;
-
       toast.add({
         severity: 'success',
         summary: 'NFC code removed!',
@@ -116,15 +114,16 @@ const deleteNfc = async () => {
       });
     })
     .catch((err) => {
-      nfcModalVisible.value = false;
-
       console.error(err);
       toast.add({
         severity: 'error',
-        summary: 'No linked NFC code.',
-        detail: 'There is no NFC code linked to your account.',
+        summary: 'API error',
+        detail: err.message,
         life: 5000,
       });
+    })
+    .finally(() => {
+      nfcModalVisible.value = false;
     });
 };
 </script>

--- a/apps/point-of-sale/src/views/CashierView.vue
+++ b/apps/point-of-sale/src/views/CashierView.vue
@@ -129,7 +129,7 @@ const nfcUpdate = async (nfcCode: string) => {
     const userId = authStore.user?.id;
     if (!userId) return;
 
-    await apiService.user.updateUserNfc(userId, { nfcCode: nfcCode }).then(async () => {});
+    await apiService.user.updateUserNfc(userId, { nfcCode: nfcCode });
   } catch (error) {
     console.error(error);
   }
@@ -137,9 +137,15 @@ const nfcUpdate = async (nfcCode: string) => {
 
 const nfcDelete = async () => {
   const userId = authStore.user?.id;
-  if (!userId) return;
+  if (!userId) {
+    throw new Error('No user logged in.');
+  }
 
-  await apiService.user.deleteUserNfc(userId).then(async () => {});
+  try {
+    await apiService.user.deleteUserNfc(userId);
+  } catch {
+    throw new Error('There is no NFC code linked to your account.');
+  }
 };
 </script>
 <style scoped lang="scss">

--- a/apps/point-of-sale/src/views/CashierView.vue
+++ b/apps/point-of-sale/src/views/CashierView.vue
@@ -26,7 +26,7 @@
     </div>
   </div>
   <SettingsIconComponent />
-  <ScannersUpdateComponent :handle-nfc-update="nfcUpdate" />
+  <ScannersUpdateComponent :handle-nfc-delete="nfcDelete" :handle-nfc-update="nfcUpdate" />
   <NfcSearchComponent :handle-nfc-search="cartStore.setBuyerFromNfc" />
 </template>
 <script setup lang="ts">
@@ -133,6 +133,13 @@ const nfcUpdate = async (nfcCode: string) => {
   } catch (error) {
     console.error(error);
   }
+};
+
+const nfcDelete = async () => {
+  const userId = authStore.user?.id;
+  if (!userId) return;
+
+  await apiService.user.deleteUserNfc(userId).then(async () => {});
 };
 </script>
 <style scoped lang="scss">


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

Adds a new button in the "Link NFC" dialogue that allows the user to remove the currently linked NFC tag from their account.

Original dialogue:
<img width="598" height="272" alt="image" src="https://github.com/user-attachments/assets/fec16c72-c2d5-46ac-8ca6-5a1c66d4fb9c" />

Dialogue after change:
<img width="589" height="306" alt="image" src="https://github.com/user-attachments/assets/7aa33303-4168-46e6-9cc3-3a6501771555" />

Once the button is pressed, `apiService.user.deleteUserNfc(user_id)` is called, which deletes the NFC tag from the database.

The dialogue is closed, and a toast with the result is shown. An error toast is shown if no NFC code is associated with the user.


## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
#572 
## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
