### PR TITLE
fix: make top up warning undraggable

### DIFF
--- a/apps/point-of-sale/src/components/TopUpWarningComponent.vue
+++ b/apps/point-of-sale/src/components/TopUpWarningComponent.vue
@@ -4,6 +4,7 @@
     :closable="false"
     :content-style="{ width: '35rem' }"
     :dismissable-mask="false"
+    :draggable="false"
     header="Please Top-Up your SudoSOS balance"
     modal
     :pt="{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->
While I was waiting for the top-up warning to allow me to skip it, I noticed that I could drag it around the page. I do not think this is expected behaviour, so I disabled it.

![draggableopopup](https://github.com/user-attachments/assets/c5f363e0-8980-431a-a48f-887f88bc9550)

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_
