### PR TITLE
feat: spinners in stripe modal to avoid confusion loading states

### DIFF
--- a/apps/dashboard/src/modules/user/components/balance/BalanceTopupModal.vue
+++ b/apps/dashboard/src/modules/user/components/balance/BalanceTopupModal.vue
@@ -14,12 +14,20 @@
     </div>
     <form v-show="!loading" id="payment-form" ref="payment">
       <div id="payment-element">
-        <!--Stripe.js injects the Payment Element-->
+        <!--Stripe.js injects the Payment Element, and replaces the spinner -->
+        <ProgressSpinner />
       </div>
     </form>
 
     <template #footer>
-      <Button class="h-9" :disabled="loading" :label="t('modules.user.balance.pay').toUpperCase()" @click="submitPay" />
+      <Button
+        v-if="!loading"
+        class="h-9"
+        :disabled="loading"
+        :label="t('modules.user.balance.pay').toUpperCase()"
+        @click="submitPay"
+      />
+      <ProgressSpinner v-else />
     </template>
   </Dialog>
 </template>
@@ -40,7 +48,7 @@ import { useDarkMode } from '@/composables/darkMode';
 
 const { t } = useI18n();
 
-const loading = ref(false);
+const loading = ref(true);
 const visible = ref(false);
 const dinero = computed((): Dinero => {
   return {
@@ -85,6 +93,9 @@ const pay = async () => {
     });
     paymentElement.value = elements.value.create('payment');
     paymentElement.value.mount('#payment-element');
+    paymentElement.value.on('ready', () => {
+      loading.value = false;
+    });
   });
 };
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title above. -->

# Description
Adds three new spinners, one enabled by default when the stripe element is still being attached, then when stripe is actually internally loading the contents of the element, and one when the pay button is clicked by stripe needs time to forward you to their website.
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
#617 

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_
