### PR TITLE
Drop -secure suffix from auth endpoint usage

### DIFF
--- a/apps/point-of-sale/src/composables/useLoginForm.ts
+++ b/apps/point-of-sale/src/composables/useLoginForm.ts
@@ -69,7 +69,7 @@ export function useLoginForm() {
 
     if (external.value) {
       authStore
-        .secureExternalPinLogin(userId.value, pinCode.value, pos.id, posApiService, userApiService)
+        .externalPinLogin(userId.value, pinCode.value, pos.id, posApiService, userApiService)
         .then(async () => {
           await loginSuccess();
         })
@@ -82,7 +82,7 @@ export function useLoginForm() {
         });
     } else {
       authStore
-        .secureGewisPinlogin(userId.value, pinCode.value, pos.id, posApiService, userApiService)
+        .gewisPinlogin(userId.value, pinCode.value, pos.id, posApiService, userApiService)
         .then(async () => {
           await loginSuccess();
         })

--- a/apps/point-of-sale/src/views/LoginView.vue
+++ b/apps/point-of-sale/src/views/LoginView.vue
@@ -117,7 +117,7 @@ const nfcLogin = async (nfcCode: string) => {
     if (!pos) {
       return;
     }
-    await authStore.secureNfcLogin(nfcCode, pos.id, posApiService, userApiService).then(async () => {
+    await authStore.nfcLogin(nfcCode, pos.id, posApiService, userApiService).then(async () => {
       await loginSuccess();
     });
   } catch (error) {
@@ -128,7 +128,11 @@ const nfcLogin = async (nfcCode: string) => {
 const eanLogin = async (eanCode: string) => {
   throw new Error('No secure ean login has been implemented yet');
   try {
-    await authStore.eanLogin(eanCode, userApiService).then(async () => {
+    const pos = posStore.getPos;
+    if (!pos) {
+      return;
+    }
+    await authStore.eanLogin(eanCode, pos!.id, posApiService, userApiService).then(async () => {
       await loginSuccess();
     });
   } catch (error) {

--- a/lib/common/src/stores/auth.store.ts
+++ b/lib/common/src/stores/auth.store.ts
@@ -14,9 +14,6 @@ import type {
   AcceptTosRequest,
   AuthenticationNfcRequest,
   AuthenticationLocalRequest,
-  MemberAuthenticationSecurePinRequest,
-  AuthenticationSecureNfcRequest,
-  AuthenticationSecurePinRequest,
 } from '@gewis/sudosos-client';
 import { jwtDecode, type JwtPayload } from 'jwt-decode';
 import { ApiService } from '../services/ApiService';
@@ -95,44 +92,24 @@ export const useAuthStore = defineStore('auth', {
       }
     },
 
-    async gewisPinlogin(userId: string, pinCode: string, service: ApiService) {
-      const userDetails: MemberAuthenticationPinRequest = {
-        memberId: parseInt(userId, 10),
-        pin: pinCode,
-      };
-
-      await service.authenticate
-        .memberPinAuthentication({ memberAuthenticationPinRequest: userDetails })
-        .then((res) => {
-          this.handleResponse(res.data, service);
-        });
-    },
-    async secureGewisPinlogin(
-      userId: string,
-      pinCode: string,
-      posId: number,
-      posService: ApiService,
-      service: ApiService,
-    ) {
-      const req: MemberAuthenticationSecurePinRequest = {
+    async gewisPinlogin(userId: string, pinCode: string, posId: number, posService: ApiService, service: ApiService) {
+      const req: MemberAuthenticationPinRequest = {
         memberId: parseInt(userId, 10),
         pin: pinCode,
         posId,
       };
 
-      await posService.authenticate
-        .secureMemberPINAuthentication({ memberAuthenticationSecurePinRequest: req })
-        .then((res) => {
-          this.handleResponse(res.data, service);
-        });
+      await posService.authenticate.memberPINAuthentication({ memberAuthenticationPinRequest: req }).then((res) => {
+        this.handleResponse(res.data, service);
+      });
     },
-    async secureNfcLogin(nfcCode: string, posId: number, posService: ApiService, service: ApiService) {
-      const req: AuthenticationSecureNfcRequest = {
+    async nfcLogin(nfcCode: string, posId: number, posService: ApiService, service: ApiService) {
+      const req: AuthenticationNfcRequest = {
         nfcCode,
         posId,
       };
 
-      await posService.authenticate.secureNfcAuthentication({ authenticationSecureNfcRequest: req }).then((res) => {
+      await posService.authenticate.nfcAuthentication({ authenticationNfcRequest: req }).then((res) => {
         this.handleResponse(res.data, service);
       });
     },
@@ -154,45 +131,30 @@ export const useAuthStore = defineStore('auth', {
         this.handleResponse(res.data, service);
       });
     },
-    async externalPinLogin(userId: number, pin: string, service: ApiService) {
-      const req: AuthenticationPinRequest = {
-        pin,
-        userId,
-      };
-      await service.authenticate.pinAuthentication({ authenticationPinRequest: req }).then((res) => {
-        this.handleResponse(res.data, service);
-      });
-    },
-    async secureExternalPinLogin(
+    async externalPinLogin(
       userId: string,
       pinCode: string,
       posId: number,
       posService: ApiService,
       service: ApiService,
     ) {
-      const req: AuthenticationSecurePinRequest = {
+      const req: AuthenticationPinRequest = {
         userId: parseInt(userId, 10),
         pin: pinCode,
         posId,
       };
 
-      await posService.authenticate.securePINAuthentication({ authenticationSecurePinRequest: req }).then((res) => {
+      await posService.authenticate.pinAuthentication({ authenticationPinRequest: req }).then((res) => {
         this.handleResponse(res.data, service);
       });
     },
-    async nfcLogin(nfcCode: string, service: ApiService) {
-      const req: AuthenticationNfcRequest = {
-        nfcCode,
-      };
-      await service.authenticate.nfcAuthentication({ authenticationNfcRequest: req }).then((res) => {
-        this.handleResponse(res.data, service);
-      });
-    },
-    async eanLogin(eanCode: string, service: ApiService) {
+    async eanLogin(eanCode: string, posId: number, posService: ApiService, service: ApiService) {
       const req: AuthenticationEanRequest = {
         eanCode,
+        posId,
       };
-      await service.authenticate.eanAuthentication({ authenticationEanRequest: req }).then((res) => {
+
+      await posService.authenticate.eanAuthentication({ authenticationEanRequest: req }).then((res) => {
         this.handleResponse(res.data, service);
       });
     },


### PR DESCRIPTION
# Description

Frontend side of backend PR GEWIS/sudosos-backend#909, which drops the `-secure` suffix from the PIN, NFC, EAN, and member-PIN auth endpoints now that the non-secure variants are gone.

Renames in the shared auth store:

- `secureGewisPinlogin` -> `gewisPinlogin`
- `secureNfcLogin` -> `nfcLogin`
- `secureExternalPinLogin` -> `externalPinLogin`

Same rename in the generated client types:

- `MemberAuthenticationSecurePinRequest` -> `MemberAuthenticationPinRequest`
- `AuthenticationSecureNfcRequest` -> `AuthenticationNfcRequest`
- `AuthenticationSecurePinRequest` -> `AuthenticationPinRequest`

The old non-secure helpers in the auth store (`gewisPinlogin`, `externalPinLogin`, `nfcLogin`, `eanLogin`) pointed at endpoints that got removed in a prior cleanup, so they no longer compile against the regenerated client. The renamed `-secure` variants take their place. `eanLogin` now takes a `posId` since that's the only `/authentication/ean` shape the API still serves.

Staying in draft until backend #909 merges and a new `@gewis/sudosos-client` ships. Then bump `package.json` to the new client hash and mark ready.

## Related issues/external references

- Backend PR: GEWIS/sudosos-backend#909
- Tracks #894 on the backend repo

## Types of changes

- Breaking change *(fix or feature that would cause existing functionality to change)*

## Test plan

- [x] `vue-tsc --noEmit` clean on POS app and shared common lib
- [x] `eslint` clean on POS, common lib, and dashboard
- [x] `vite build` clean on POS and dashboard apps
- [x] Dashboard `vue-tsc` shows only the 3 pre-existing TS2742 axios-mismatch errors that already exist on `develop`