### PR TITLE
fix: only show admin dashboard with correct permissions

### DIFF
--- a/apps/dashboard/src/modules/admin/routes.ts
+++ b/apps/dashboard/src/modules/admin/routes.ts
@@ -8,6 +8,16 @@ import AdminMaintainerView from '@/modules/admin/views/AdminMaintainerView.vue';
 import AdminRBACView from '@/modules/admin/views/AdminRBACView.vue';
 import AdminDashboardView from '@/modules/admin/views/AdminDashboardView.vue';
 
+export function canViewAdminDashboard(): boolean {
+  return (
+    isAllowed('get', ['all'], 'User', ['any']) &&
+    isAllowed('get', ['all'], 'Balance', ['any']) &&
+    isAllowed('get', ['all'], 'PayoutRequest', ['any']) &&
+    isAllowed('get', ['all'], 'Invoice', ['any']) &&
+    isAllowed('get', ['all'], 'Fine', ['any'])
+  );
+}
+
 export function adminRoutes(): RouteRecordRaw[] {
   return [
     {
@@ -21,7 +31,7 @@ export function adminRoutes(): RouteRecordRaw[] {
           name: 'adminDashboard',
           meta: {
             requiresAuth: true,
-            isAllowed: () => isAllowed('get', ['all'], 'User', ['any']),
+            isAllowed: () => canViewAdminDashboard(),
             title: 'modules.admin.dashboard.title',
           },
         },

--- a/apps/dashboard/src/router/index.ts
+++ b/apps/dashboard/src/router/index.ts
@@ -5,7 +5,7 @@ import PublicLayout from '@/layout/PublicLayout.vue';
 import DashboardLayout from '@/layout/DashboardLayout.vue';
 import ErrorView from '@/views/ErrorView.vue';
 import { authRoutes } from '@/modules/auth/routes';
-import { adminRoutes } from '@/modules/admin/routes';
+import { adminRoutes, canViewAdminDashboard } from '@/modules/admin/routes';
 import { financialRoutes } from '@/modules/financial/routes';
 import { sellerRoutes } from '@/modules/seller/routes';
 import { userRoutes } from '@/modules/user/routes';
@@ -129,12 +129,7 @@ router.beforeEach((to, from, next) => {
   } else if (!to.meta?.requiresAuth && isAuth && hasTOSAccepted() == 'ACCEPTED') {
     // If the route doesn't require authentication and the user is authenticated, redirect to home
     next({ name: 'home' });
-  } else if (
-    to.name === 'home' &&
-    isBetaEnabled() &&
-    window.innerWidth >= 1024 &&
-    isAllowed('get', ['all'], 'User', ['any'])
-  ) {
+  } else if (to.name === 'home' && isBetaEnabled() && window.innerWidth >= 1024 && canViewAdminDashboard()) {
     // Beta admin on desktop: go to admin landing page
     next({ name: 'adminDashboard' });
   } else if (to.meta?.isAllowed) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description
Users who did not have permission to make all the calls required to populate the admin dashboard were redirected anyway. This made it so that they were shown an (almost) empty dashboard, which is not useful.
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
